### PR TITLE
Use `Decoder::read` in `read_ipv4`

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -130,8 +130,8 @@ impl<'a> Decoder<'a> {
         if length != 4 {
             return Err(DecodeError::NotEnoughBytes);
         }
-        let bytes = self.read_slice(length as usize)?;
-        Ok([bytes[0], bytes[1], bytes[2], bytes[3]].into())
+        let bytes = self.read::<4>()?;
+        Ok(bytes.into())
     }
 
     /// Read a list of ipv4 addrs


### PR DESCRIPTION
Hey there! Amazing work with this crate :D

Since `read_ipv4` will refuse any length different than four, I don't see why we couldn't use the const generics-backed `read` function