### PR TITLE
Replace Decoder's cursor with split_at, 10-18% opt

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -74,6 +74,7 @@ impl<'a> Decoder<'a> {
         }
         let (slice, remaining) = self.buffer.split_at(N);
         self.buffer = remaining;
+        // can't panic-- condition checked above
         Ok(slice.try_into().unwrap())
     }
 


### PR DESCRIPTION
Replacing the cursor with split_at removes the addition operations from all reads, which removes the overflow check and error return path. The remaining overflow case is only where the index is out of bounds anyway, so we don't care.

This is almost the same patch that I sent to trust-dns some time ago: https://github.com/bluejekyll/trust-dns/pull/1399/files

The only potential problem is that `DecodeError::EndOfBuffer` is no longer constructed by this crate, because this PR removes the information required to construct it.

Here's my before-and-after criterion:
```
decode/decode_offer     time:   [687.25 ns 687.60 ns 687.96 ns]
                        change: [-15.317% -15.244% -15.169%] (p = 0.00 < 0.05)
                        Performance has improved.
decode/decode_bootreq   time:   [118.94 ns 119.04 ns 119.14 ns]
                        change: [-18.150% -18.091% -18.035%] (p = 0.00 < 0.05)
                        Performance has improved.
decode/decode_discover  time:   [305.14 ns 306.90 ns 309.28 ns]
                        change: [-10.085% -9.8152% -9.4779%] (p = 0.00 < 0.05)
                        Performance has improved.
decode/decode_other_offer
                        time:   [739.55 ns 739.91 ns 740.28 ns]
                        change: [-14.004% -13.941% -13.871%] (p = 0.00 < 0.05)
                        Performance has improved.
```