### PR TITLE
add subnetselection opt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "dhcproto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dhcproto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ian Laidlaw <ilaidlaw@bluecatnetworks.com>", "Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -220,7 +220,7 @@ pub enum OptionCode {
     ClientIdentifier,
     /// 82 Relay Agent Information
     RelayAgentInformation,
-    /// 118 Subnet option
+    /// 118 Subnet option - <https://datatracker.ietf.org/doc/html/rfc3011>
     SubnetSelection,
     /// Unknown option
     Unknown(u8),
@@ -496,7 +496,7 @@ pub enum DhcpOption {
     ClientIdentifier(Vec<u8>),
     /// 82 Relay Agent Information - <https://datatracker.ietf.org/doc/html/rfc3046>
     RelayAgentInformation(relay::RelayAgentInformation),
-    /// 118 Subnet selection
+    /// 118 Subnet selection - <https://datatracker.ietf.org/doc/html/rfc3011>
     SubnetSelection(Ipv4Addr),
     /// Unknown option
     Unknown(UnknownOption),


### PR DESCRIPTION
Adds `SubnetSelection` to dhcp options. I considered adding `#[non_exhaustive]` to the various opt enums so future additions wouldn't be a breaking change. But I think the likelihood that users are exhaustively matching on it is low, most probably just use `msg.opts().get(OptionCode::Blah)`