### PR TITLE
finer grained relay agent info

### DIFF
--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -31,7 +31,7 @@ impl Flags {
     }
     /// get the status of the broadcast flag
     pub fn broadcast(&self) -> bool {
-        (self.0 & 0x80_00) >> 15 == 1
+        (self.0 & 0x80_00) >> (u16::BITS - 1) == 1
     }
     /// set the broadcast bit, returns a new Flags
     pub fn set_broadcast(mut self) -> Self {
@@ -73,6 +73,7 @@ mod tests {
         assert_eq!(flag.0, 0);
         let flag = flag.set_broadcast();
         assert_eq!(flag.0, 0x80_00);
+        assert!(flag.broadcast());
 
         let flag = Flags::new(0x00_20).set_broadcast();
         assert_eq!(flag.0, 0x80_20);

--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Flags {
 impl Flags {
     /// Create new Flags from u16
     pub fn new(n: u16) -> Self {
-        Flags(n)
+        Self(n)
     }
     /// get the status of the broadcast flag
     pub fn broadcast(&self) -> bool {
@@ -42,7 +42,7 @@ impl Flags {
 
 impl From<u16> for Flags {
     fn from(n: u16) -> Self {
-        Flags(n)
+        Self(n)
     }
 }
 impl From<Flags> for u16 {

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -1022,6 +1022,21 @@ pub struct UnknownOption {
     bytes: Vec<u8>,
 }
 
+impl UnknownOption {
+    /// return the relay code
+    pub fn code(&self) -> OptionCode {
+        self.code.into()
+    }
+    /// return the data for this code
+    pub fn data(&self) -> &[u8] {
+        &self.bytes
+    }
+    /// take ownership and return the parts of this
+    pub fn into_parts(self) -> (OptionCode, Vec<u8>) {
+        (self.code.into(), self.bytes)
+    }
+}
+
 /// The DHCP message type
 /// <https://datatracker.ietf.org/doc/html/rfc2131#section-3.1>
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -1,17 +1,48 @@
 //!
-use std::collections::HashMap;
+use std::{
+    collections::{hash_map, HashMap},
+    fmt,
+    net::Ipv4Addr,
+};
 
 use crate::{Decodable, Encodable};
 
 /// Collection of relay agent information
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RelayAgentInformation(HashMap<RelayCode, Info>);
+pub struct RelayAgentInformation(HashMap<RelayCode, RelayInfo>);
+
+impl RelayAgentInformation {
+    /// Get the data for a particular RelayCode
+    pub fn get(&self, code: RelayCode) -> Option<&RelayInfo> {
+        self.0.get(&code)
+    }
+    /// Get the mutable data for a particular OptionCode
+    pub fn get_mut(&mut self, code: RelayCode) -> Option<&mut RelayInfo> {
+        self.0.get_mut(&code)
+    }
+    /// remove option
+    pub fn remove(&mut self, code: RelayCode) -> Option<RelayInfo> {
+        self.0.remove(&code)
+    }
+    /// insert a new option
+    pub fn insert(&mut self, info: RelayInfo) -> Option<RelayInfo> {
+        self.0.insert((&info).into(), info)
+    }
+    /// iterate over entries
+    pub fn iter(&self) -> hash_map::Iter<'_, RelayCode, RelayInfo> {
+        self.0.iter()
+    }
+    /// iterate mutably over entries
+    pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, RelayCode, RelayInfo> {
+        self.0.iter_mut()
+    }
+}
 
 impl Decodable for RelayAgentInformation {
     fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
         let mut opts = HashMap::new();
-        while let Ok(opt) = Info::decode(d) {
-            opts.insert(opt.code, opt);
+        while let Ok(opt) = RelayInfo::decode(d) {
+            opts.insert(RelayCode::from(&opt), opt);
         }
         Ok(RelayAgentInformation(opts))
     }
@@ -23,43 +54,220 @@ impl Encodable for RelayAgentInformation {
     }
 }
 
-/// Relay agent information
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Info {
-    code: RelayCode,
-    // use just bytes for now
-    data: Vec<u8>,
+pub enum RelayInfo {
+    /// 1 - <https://datatracker.ietf.org/doc/html/rfc3046>
+    AgentCircuitId(Vec<u8>),
+    /// 2 - <https://datatracker.ietf.org/doc/html/rfc3046>
+    AgentRemoteId(Vec<u8>),
+    /// 3 - <https://datatracker.ietf.org/doc/html/rfc3256>
+    DocsisDeviceClass(u32),
+    /// 5 - <https://datatracker.ietf.org/doc/html/rfc3527>
+    LinkSelection(Ipv4Addr),
+    /// 6 - <https://datatracker.ietf.org/doc/html/rfc3993#section-3.1>
+    SubscriberId(Vec<u8>),
+    /// 10 - <https://datatracker.ietf.org/doc/html/rfc5010#section-3>
+    RelayAgentFlags(RelayFlags),
+    /// 11 - <https://datatracker.ietf.org/doc/html/rfc5107#section-4>
+    ServerIdentifierOverride(Ipv4Addr),
+    Unknown(UnknownInfo),
+    // TODO: not tackling this at the moment
+    // 7 - <https://datatracker.ietf.org/doc/html/rfc4014>
+    // RadiusAttributes,
+    // 8 - <https://datatracker.ietf.org/doc/html/rfc4030#section-4>
+    // 9
+    // VendorSpecificInformation(Vec<u8>),
+    // Authentication(Authentication),
+    // 151 - <https://datatracker.ietf.org/doc/html/rfc6607>
+    // VirtualSubnet(VirtualSubnet),
+    // 152
+    // VirtualSubnetControl(u8),
 }
 
-impl Info {
+impl Decodable for RelayInfo {
+    fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
+        use RelayInfo::*;
+        // read the code first, determines the variant
+
+        // pad has no length, so we can't read len up here
+        Ok(match d.read_u8()?.into() {
+            RelayCode::AgentCircuitId => {
+                let len = d.read_u8()? as usize;
+                let data = d.read_slice(len)?.to_vec();
+                AgentCircuitId(data)
+            }
+            RelayCode::AgentRemoteId => {
+                let len = d.read_u8()? as usize;
+                let data = d.read_slice(len)?.to_vec();
+                AgentCircuitId(data)
+            }
+            RelayCode::DocsisDeviceClass => {
+                let device_id = d.read_u32()?;
+                DocsisDeviceClass(device_id)
+            }
+            RelayCode::LinkSelection => {
+                let len = d.read_u8()? as usize;
+                LinkSelection(d.read_ipv4(len)?)
+            }
+            RelayCode::SubscriberId => {
+                let len = d.read_u8()? as usize;
+                let data = d.read_slice(len)?.to_vec();
+                SubscriberId(data)
+            }
+            RelayCode::RelayAgentFlags => {
+                let _len = d.read_u8()?;
+                let flags = d.read_u8()?;
+                RelayAgentFlags(flags.into())
+            }
+            RelayCode::ServerIdentifierOverride => {
+                let len = d.read_u8()? as usize;
+                ServerIdentifierOverride(d.read_ipv4(len)?)
+            }
+            // we have codes for these but not full type definitions yet
+            code
+            @
+            (RelayCode::Authentication
+            | RelayCode::VirtualSubnet
+            | RelayCode::VirtualSubnetControl
+            | RelayCode::RadiusAttributes
+            | RelayCode::VendorSpecificInformation) => {
+                let length = d.read_u8()?;
+                let bytes = d.read_slice(length as usize)?.to_vec();
+                Unknown(UnknownInfo {
+                    code: code.into(),
+                    bytes,
+                })
+            }
+            // not yet implemented
+            RelayCode::Unknown(code) => {
+                let length = d.read_u8()?;
+                let bytes = d.read_slice(length as usize)?.to_vec();
+                Unknown(UnknownInfo { code, bytes })
+            }
+        })
+    }
+}
+
+// pub struct VirtualSubnet {
+//     code: VssInfo,
+// }
+
+// pub enum VssInfo {
+//     NvtVpnId,
+//     VpnId,
+//     Unassigned,
+//     GlobalVpn,
+// }
+
+// impl From<u8> for VssInfo {
+//     fn from(n: u8) -> Self {
+//         match n {
+//             0 => VssInfo::NvtVpnId,
+//             1 => VssInfo::VpnId,
+//             2..=254 => VssInfo::Unassigned,
+//             255 => VssInfo::GlobalVpn,
+//         }
+//     }
+// }
+
+impl Encodable for RelayInfo {
+    fn encode(&self, e: &mut crate::Encoder<'_>) -> super::EncodeResult<()> {
+        use RelayInfo::*;
+
+        let code: RelayCode = self.into();
+
+        e.write_u8(code.into())?;
+        match self {
+            AgentCircuitId(id) | AgentRemoteId(id) | SubscriberId(id) => {
+                // length of bytes stored in Vec
+                e.write_u8(id.len() as u8)?;
+                e.write_slice(id)?
+            }
+            DocsisDeviceClass(n) => {
+                e.write_u8(4)?;
+                e.write_u32(*n)?
+            }
+            LinkSelection(addr) | ServerIdentifierOverride(addr) => {
+                e.write_u8(4)?;
+                e.write_u32((*addr).into())?
+            }
+            RelayAgentFlags(flags) => {
+                e.write_u8(0)?;
+                e.write_u8((*flags).into())?
+            }
+            // not yet implemented
+            Unknown(opt) => {
+                // length of bytes stored in Vec
+                e.write_u8(opt.bytes.len() as u8)?;
+                e.write_slice(&opt.bytes)?
+            }
+        };
+        Ok(())
+    }
+}
+#[derive(Copy, Default, Clone, PartialEq, Eq)]
+pub struct RelayFlags(u8);
+
+impl fmt::Debug for RelayFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RelayFlags")
+            .field("unicast", &self.unicast())
+            .finish()
+    }
+}
+
+impl fmt::Display for RelayFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl RelayFlags {
+    /// Create new RelayFlags from u8
+    pub fn new(n: u8) -> Self {
+        Self(n)
+    }
+    /// get the status of the unicast flag
+    pub fn unicast(&self) -> bool {
+        (self.0 & 0x80) >> 7 == 1
+    }
+    /// set the unicast bit, returns a new Flags
+    pub fn set_unicast(mut self) -> Self {
+        self.0 |= 0x80;
+        self
+    }
+}
+
+impl From<u8> for RelayFlags {
+    fn from(n: u8) -> Self {
+        Self(n)
+    }
+}
+impl From<RelayFlags> for u8 {
+    fn from(f: RelayFlags) -> Self {
+        f.0
+    }
+}
+
+/// An as-of-yet unimplemented relay info
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnknownInfo {
+    code: u8,
+    bytes: Vec<u8>,
+}
+
+impl UnknownInfo {
     /// return the relay code
     pub fn code(&self) -> RelayCode {
-        self.code
+        self.code.into()
     }
     /// return the data for this code
     pub fn data(&self) -> &[u8] {
-        &self.data
+        &self.bytes
     }
     /// take ownership and return the parts of this
     pub fn into_parts(self) -> (RelayCode, Vec<u8>) {
-        (self.code, self.data)
-    }
-}
-
-impl Decodable for Info {
-    fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
-        let code = d.read_u8()?.into();
-        let len = d.read_u8()? as usize;
-        let data = d.read_slice(len)?.to_vec();
-        Ok(Self { code, data })
-    }
-}
-
-impl Encodable for Info {
-    fn encode(&self, e: &mut crate::Encoder<'_>) -> super::EncodeResult<()> {
-        e.write_u8(self.code.into())?;
-        e.write_u8(self.data.len() as u8)?;
-        e.write_slice(&self.data)
+        (self.code.into(), self.bytes)
     }
 }
 
@@ -120,5 +328,81 @@ impl From<RelayCode> for u8 {
             VirtualSubnetControl => 152,
             Unknown(n) => n,
         }
+    }
+}
+
+impl From<&RelayInfo> for RelayCode {
+    fn from(info: &RelayInfo) -> Self {
+        match info {
+            RelayInfo::AgentCircuitId(_) => RelayCode::AgentCircuitId,
+            RelayInfo::AgentRemoteId(_) => RelayCode::AgentRemoteId,
+            RelayInfo::DocsisDeviceClass(_) => RelayCode::DocsisDeviceClass,
+            RelayInfo::LinkSelection(_) => RelayCode::LinkSelection,
+            RelayInfo::SubscriberId(_) => RelayCode::SubscriberId,
+            RelayInfo::RelayAgentFlags(_) => RelayCode::RelayAgentFlags,
+            RelayInfo::ServerIdentifierOverride(_) => RelayCode::ServerIdentifierOverride,
+            RelayInfo::Unknown(unknown) => RelayCode::Unknown(unknown.code),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    #[test]
+    fn test_unicast() {
+        let flag = RelayFlags::default();
+        assert_eq!(flag.0, 0);
+        let flag = flag.set_unicast();
+        assert_eq!(flag.0, 0x80);
+
+        let flag = RelayFlags::new(0x00).set_unicast();
+        assert_eq!(flag.0, 0x80);
+        assert!(flag.unicast());
+    }
+
+    fn test_opt(opt: RelayInfo, actual: Vec<u8>) -> Result<()> {
+        let mut out = vec![];
+        let mut enc = crate::Encoder::new(&mut out);
+        opt.encode(&mut enc)?;
+        println!("{:?}", enc.buffer());
+        assert_eq!(out, actual);
+
+        let buf = RelayInfo::decode(&mut crate::Decoder::new(&out))?;
+        assert_eq!(buf, opt);
+        Ok(())
+    }
+    // #[test]
+    // fn test_opts() -> Result<()> {
+    //     let input = binput();
+    //     println!("{:?}", input);
+    //     let opts = DhcpOptions::decode(&mut Decoder::new(&input))?;
+
+    //     let mut output = Vec::new();
+    //     let _len = opts.encode(&mut Encoder::new(&mut output))?;
+    //     // not comparing len as we don't add PAD bytes
+    //     // assert_eq!(input.len(), len);
+    //     Ok(())
+    // }
+
+    #[test]
+    fn test_ip() -> Result<()> {
+        test_opt(
+            RelayInfo::LinkSelection("192.168.0.1".parse::<Ipv4Addr>().unwrap()),
+            vec![5, 4, 192, 168, 0, 1],
+        )?;
+        Ok(())
+    }
+    #[test]
+    fn test_str() -> Result<()> {
+        test_opt(
+            RelayInfo::AgentCircuitId(vec![0, 1, 2, 3, 4]),
+            vec![1, 5, 0, 1, 2, 3, 4],
+        )?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Had to engage with relay options today and realized that methods were not made public to actually interact with it. `Info` was not ever actually accessible AFAICT. 

Relay agent sub-options work similarly to the upper level dhcp options, just sitting inside opt 82. This implementation borrows a lot of the same code for that, I've skipped some opts that were just too onerous to figure out for now, those will be decoded into the `UnknownInfo` variant and the bytes can be pulled out that way.