### PR TITLE
erase iterator from opts/relayinfo

### DIFF
--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{hash_map, HashMap},
-    iter,
-    net::Ipv4Addr,
-};
+use std::{collections::HashMap, iter, net::Ipv4Addr};
 
 use crate::{
     decoder::{Decodable, Decoder},

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -34,11 +34,11 @@ impl DhcpOptions {
         self.0.insert((&opt).into(), opt)
     }
     /// iterate over entries
-    pub fn iter(&self) -> hash_map::Iter<'_, OptionCode, DhcpOption> {
+    pub fn iter(&self) -> impl Iterator<Item = (&OptionCode, &DhcpOption)> {
         self.0.iter()
     }
     /// iterate mutably over entries
-    pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, OptionCode, DhcpOption> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&OptionCode, &mut DhcpOption)> {
         self.0.iter_mut()
     }
     /// return message type

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -1,9 +1,5 @@
 //!
-use std::{
-    collections::{hash_map, HashMap},
-    fmt,
-    net::Ipv4Addr,
-};
+use std::{collections::HashMap, fmt, net::Ipv4Addr};
 
 use crate::{Decodable, Encodable};
 
@@ -29,11 +25,11 @@ impl RelayAgentInformation {
         self.0.insert((&info).into(), info)
     }
     /// iterate over entries
-    pub fn iter(&self) -> hash_map::Iter<'_, RelayCode, RelayInfo> {
+    pub fn iter(&self) -> impl Iterator<Item = (&RelayCode, &RelayInfo)> {
         self.0.iter()
     }
     /// iterate mutably over entries
-    pub fn iter_mut(&mut self) -> hash_map::IterMut<'_, RelayCode, RelayInfo> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&RelayCode, &mut RelayInfo)> {
         self.0.iter_mut()
     }
 }
@@ -88,8 +84,6 @@ impl Decodable for RelayInfo {
     fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
         use RelayInfo::*;
         // read the code first, determines the variant
-
-        // pad has no length, so we can't read len up here
         Ok(match d.read_u8()?.into() {
             RelayCode::AgentCircuitId => {
                 let len = d.read_u8()? as usize;

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -1,4 +1,3 @@
-use core::slice;
 use std::net::Ipv6Addr;
 
 use crate::{
@@ -47,7 +46,7 @@ impl DhcpOptions {
         self.0.iter()
     }
     /// return a mutable ref to an iterator
-    pub fn iter_mut(&mut self) -> slice::IterMut<'_, DhcpOption> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DhcpOption> {
         self.0.iter_mut()
     }
 }


### PR DESCRIPTION
erase concrete iterator types in favor of `impl Iterator`