### PR TITLE
0.5.0 & add to changelog

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,7 +60,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -87,8 +86,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- added clear/is_empty/retain to v4 opts & relay agent sub opts
+## [0.5.0]
+
+### Added
+
+- added `clear`/`is_empty`/`retain` to v4 opts & relay agent sub-opts
+
+### Fixed
+
+- **breaking** options enum for `v4::DhcpOption` was decoding into the wrong variants for a few types
 
 ## [0.4.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "dhcproto"
-version = "0.4.2-alpha.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dhcproto"
-version = "0.4.2-alpha.1"
+version = "0.5.0"
 authors = ["Ian Laidlaw <ilaidlaw@bluecatnetworks.com>", "Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2018"
 description = """


### PR DESCRIPTION
Added previous changes/fixes to `CHANGELOG`, cut 0.5.0 release. The variant brokenness for `DhcpOption` needs to go out