### PR TITLE
Impl serde optionally for types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,8 @@ version = "0.8.0-alpha"
 dependencies = [
  "criterion",
  "rand",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -476,6 +478,9 @@ name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_cbor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ license = "MIT"
 [dependencies]
 thiserror = "1.0"
 rand = "0.8"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1.0"
 
 [[bench]]
 name = "decode"

--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -6,7 +6,11 @@ use crate::{
     error::{DecodeResult, EncodeResult},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Represents available flags on message
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Default, Clone, PartialEq, Eq)]
 pub struct Flags(u16);
 

--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -4,7 +4,11 @@ use crate::{
     error::{DecodeResult, EncodeResult},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Hardware type of message
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
 pub enum HType {
     /// 1 Ethernet

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -80,6 +80,9 @@
 //!
 use std::{net::Ipv4Addr, str::Utf8Error};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod flags;
 mod htype;
 mod opcode;
@@ -130,6 +133,7 @@ pub const CLIENT_PORT: u16 = 68;
 /// |                          options (variable)                   |
 /// +---------------------------------------------------------------+
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Message {
     /// op code / message type
@@ -562,6 +566,15 @@ mod tests {
         );
         msg.set_chaddr(&[0, 1, 2, 3, 4, 5]);
         assert_eq!(msg.chaddr().len(), 6);
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_json() -> Result<()> {
+        let msg = Message::decode(&mut Decoder::new(&bootreq()))?;
+        let s = serde_json::to_string(&msg)?;
+        println!("{:?}", s);
         Ok(())
     }
 

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -572,9 +572,11 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_json() -> Result<()> {
-        let msg = Message::decode(&mut Decoder::new(&bootreq()))?;
-        let s = serde_json::to_string(&msg)?;
-        println!("{:?}", s);
+        let msg = Message::decode(&mut Decoder::new(&offer()))?;
+        let s = serde_json::to_string_pretty(&msg)?;
+        println!("{s}");
+        let other = serde_json::from_str(&s)?;
+        assert_eq!(msg, other);
         Ok(())
     }
 

--- a/src/v4/opcode.rs
+++ b/src/v4/opcode.rs
@@ -3,8 +3,11 @@ use crate::{
     encoder::{Encodable, Encoder},
     error::{DecodeResult, EncodeResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Opcode of Message
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Opcode {
     /// BootRequest - <https://datatracker.ietf.org/doc/html/rfc1534#section-2>

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -7,6 +7,9 @@ use crate::{
     v4::relay,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Options for DHCP. This implemention of options ignores PAD bytes.
 ///
 /// ex
@@ -27,6 +30,7 @@ use crate::{
 ///          v4::OptionCode::DomainName,
 ///       ]));
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DhcpOptions(HashMap<OptionCode, DhcpOption>);
 
@@ -135,6 +139,7 @@ impl Encodable for DhcpOptions {
 }
 
 /// Each option type is represented by an 8-bit code
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
 pub enum OptionCode {
     /// 0 Padding
@@ -406,6 +411,7 @@ impl From<OptionCode> for u8 {
 }
 
 /// DHCP Options
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DhcpOption {
     /// 0 Padding
@@ -540,6 +546,7 @@ pub enum DhcpOption {
 }
 
 /// NetBIOS allows several different node types
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NodeType {
     /// Broadcast
@@ -1051,6 +1058,7 @@ impl From<&DhcpOption> for OptionCode {
 }
 
 /// An as-of-yet unimplemented option type
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnknownOption {
     code: u8,
@@ -1080,6 +1088,7 @@ impl UnknownOption {
 
 /// The DHCP message type
 /// <https://datatracker.ietf.org/doc/html/rfc2131#section-3.1>
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MessageType {
     /// DHCPDiscover

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -3,6 +3,9 @@ use std::{collections::HashMap, fmt, net::Ipv4Addr};
 
 use crate::{Decodable, Encodable};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Collection of relay agent information
 ///
 /// You can create/modify it, then insert into a message opts section
@@ -19,6 +22,7 @@ use crate::{Decodable, Encodable};
 /// ```
 ///
 /// [`DhcpOption::RelayAgentInformation`]: crate::v4::DhcpOption::RelayAgentInformation
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RelayAgentInformation(HashMap<RelayCode, RelayInfo>);
 
@@ -86,6 +90,7 @@ impl Encodable for RelayAgentInformation {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelayInfo {
     /// 1 - <https://datatracker.ietf.org/doc/html/rfc3046>
@@ -210,6 +215,8 @@ impl Encodable for RelayInfo {
         Ok(())
     }
 }
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Default, Clone, PartialEq, Eq)]
 pub struct RelayFlags(u8);
 
@@ -255,6 +262,7 @@ impl From<RelayFlags> for u8 {
 }
 
 /// An as-of-yet unimplemented relay info
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnknownInfo {
     code: u8,
@@ -283,6 +291,7 @@ impl UnknownInfo {
 }
 
 /// relay code, represented as a u8
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum RelayCode {
     AgentCircuitId,

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -54,6 +54,9 @@
 //!
 mod options;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::convert::TryInto;
 
 // re-export submodules from proto::msg
@@ -110,6 +113,7 @@ pub const CLIENT_PORT: u16 = 546;
 ///                           field (4 octets less than the size of the
 ///                           message).
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Message {
     /// message type
@@ -202,6 +206,7 @@ impl Message {
 
 /// DHCPv6 message types
 /// <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MessageType {
     // RFC 3315
@@ -393,6 +398,17 @@ mod tests {
     #[test]
     fn decode_reply() -> Result<()> {
         decode_ipv6(reply(), MessageType::Reply)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_json_v6() -> Result<()> {
+        let msg = Message::decode(&mut Decoder::new(&solicit()))?;
+        let s = serde_json::to_string_pretty(&msg)?;
+        println!("{s}");
+        let other = serde_json::from_str(&s)?;
+        assert_eq!(msg, other);
         Ok(())
     }
 

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use std::net::Ipv6Addr;
 
 use crate::{
@@ -12,6 +15,7 @@ use crate::{
 // <https://datatracker.ietf.org/doc/html/rfc8415#section-6.6>
 
 /// <https://datatracker.ietf.org/doc/html/rfc8415#section-21>
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DhcpOptions(Vec<DhcpOption>);
 
@@ -52,6 +56,7 @@ impl DhcpOptions {
 }
 
 /// DHCPv6 option types
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DhcpOption {
     /// 1 - <https://datatracker.ietf.org/doc/html/rfc8415#section-21.2>
@@ -110,6 +115,7 @@ pub struct InterfaceId {
 }
 
 /// vendor options
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VendorOpts {
     pub num: u32,
@@ -118,6 +124,7 @@ pub struct VendorOpts {
 }
 
 /// vendor class
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VendorClass {
     pub num: u32,
@@ -126,6 +133,7 @@ pub struct VendorClass {
 }
 
 /// user class
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UserClass {
     pub data: Vec<Vec<u8>>,
@@ -147,6 +155,7 @@ fn decode_data(decoder: &'_ mut Decoder<'_>) -> Vec<Vec<u8>> {
 }
 
 /// Server Unicast
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StatusCode {
     pub status: Status,
@@ -155,6 +164,7 @@ pub struct StatusCode {
 }
 
 /// Status code for Server Unicast
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Status {
     Success,
@@ -248,6 +258,7 @@ impl From<Status> for u16 {
 }
 
 /// Authentication
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Authentication {
     pub proto: u8,
@@ -272,6 +283,7 @@ impl Decodable for Authentication {
 }
 
 /// Relay Msg
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RelayMsg {
     /// DHCP-relay-message In a Relay-forward message, the received
@@ -297,6 +309,7 @@ impl RelayMsg {
 
 /// Option Request Option
 /// <https://datatracker.ietf.org/doc/html/rfc8415#section-21.7>
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ORO {
     // 2 * num opts
@@ -320,6 +333,7 @@ impl Decodable for ORO {
 }
 
 /// Identity Association for Temporary Addresses
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IATA {
     pub id: u32,
@@ -339,6 +353,7 @@ impl Decodable for IATA {
 }
 
 /// Identity Association for Non-Temporary Addresses
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IANA {
     pub id: u32,
@@ -360,6 +375,7 @@ impl Decodable for IANA {
 }
 
 /// Identity Association Prefix Delegation
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IAPD {
     pub id: u32,
@@ -381,6 +397,7 @@ impl Decodable for IAPD {
 }
 
 /// Identity Association Prefix Delegation Prefix Option
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IAPDPrefix {
     pub preferred_lifetime: u32,
@@ -404,6 +421,7 @@ impl Decodable for IAPDPrefix {
 }
 
 /// Identity Association Address
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IAAddr {
     pub addr: Ipv6Addr,
@@ -427,6 +445,7 @@ impl Decodable for IAAddr {
 }
 
 /// fallback for options not yet implemented
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnknownOption {
     code: u16,
@@ -721,6 +740,7 @@ impl Encodable for DhcpOption {
 }
 
 /// option code type
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OptionCode {
     /// 1


### PR DESCRIPTION
I thought it might be valuable to encode these types as JSON, say for logging purposes. I added an optional feature `"serde"` that when enabled, allows the types to be encoded/decoded using `serde`