### PR TITLE
make opt not impl Decodable

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,12 +11,12 @@ use std::{
 };
 
 /// A trait for types which are serializable to and from DHCP binary formats
-pub trait Decodable<'a>: Sized {
+pub trait Decodable: Sized {
     /// Read the type from the stream
-    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self>;
+    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self>;
 
     /// Returns the object in binary form
-    fn from_bytes(bytes: &'a [u8]) -> DecodeResult<Self> {
+    fn from_bytes(bytes: &[u8]) -> DecodeResult<Self> {
         let mut decoder = Decoder::new(bytes);
         Self::decode(&mut decoder)
     }

--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -55,7 +55,7 @@ impl From<Flags> for u16 {
     }
 }
 
-impl Decodable<'_> for Flags {
+impl Decodable for Flags {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(decoder.read_u16()?.into())
     }

--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -141,7 +141,7 @@ impl From<HType> for u8 {
     }
 }
 
-impl Decodable<'_> for HType {
+impl Decodable for HType {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(decoder.read_u8()?.into())
     }

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -455,7 +455,7 @@ impl Message {
     }
 }
 
-impl Decodable<'_> for Message {
+impl Decodable for Message {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(Message {
             opcode: Opcode::decode(decoder)?,

--- a/src/v4/opcode.rs
+++ b/src/v4/opcode.rs
@@ -18,7 +18,7 @@ pub enum Opcode {
     Unknown(u8),
 }
 
-impl Decodable<'_> for Opcode {
+impl Decodable for Opcode {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(decoder.read_u8()?.into())
     }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -156,7 +156,7 @@ impl DhcpOptions {
     }
 }
 
-impl Decodable<'_> for DhcpOptions {
+impl Decodable for DhcpOptions {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         // represented as a vector in the actual message
         let mut opts = HashMap::new();
@@ -979,7 +979,7 @@ fn decode_inner(
     })
 }
 
-impl Decodable<'_> for DhcpOption {
+impl Decodable for DhcpOption {
     #[inline]
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         #[derive(Debug)]
@@ -998,10 +998,7 @@ impl Decodable<'_> for DhcpOption {
 
                 decode_inner(code, opt_decoder.buffer().len(), &mut opt_decoder)
             }
-        }
-
-        impl<'a> Decodable<'a> for Opt<'a> {
-            #[inline]
+            // can't implement Decodable b/c of lifetime issues
             fn decode(dec: &mut Decoder<'a>) -> DecodeResult<Self> {
                 // TODO: necessary to call u8::from_be_bytes?
                 let [code, len] = dec.peek::<2>()?;
@@ -1430,7 +1427,7 @@ impl UnknownOption {
     }
 }
 
-impl Decodable<'_> for UnknownOption {
+impl Decodable for UnknownOption {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         let code = decoder.read_u8()?;
         let length = decoder.read_u8()?;

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -74,7 +74,7 @@ impl RelayAgentInformation {
     }
 }
 
-impl Decodable<'_> for RelayAgentInformation {
+impl Decodable for RelayAgentInformation {
     fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
         let mut opts = HashMap::new();
         while let Ok(opt) = RelayInfo::decode(d) {
@@ -121,7 +121,7 @@ pub enum RelayInfo {
     // VirtualSubnetControl(u8),
 }
 
-impl Decodable<'_> for RelayInfo {
+impl Decodable for RelayInfo {
     fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
         use RelayInfo::*;
         // read the code first, determines the variant

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -330,7 +330,7 @@ impl From<MessageType> for u8 {
     }
 }
 
-impl Decodable<'_> for Message {
+impl Decodable for Message {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(Message {
             msg_type: decoder.read_u8()?.into(),

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -269,7 +269,7 @@ pub struct Authentication {
     pub info: Vec<u8>,
 }
 
-impl Decodable<'_> for Authentication {
+impl Decodable for Authentication {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         let len = decoder.buffer().len();
         Ok(Authentication {
@@ -316,7 +316,7 @@ pub struct ORO {
     pub opts: Vec<OptionCode>,
 }
 
-impl Decodable<'_> for ORO {
+impl Decodable for ORO {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         let len = decoder.buffer().len();
         Ok(ORO {
@@ -343,7 +343,7 @@ pub struct IATA {
     pub opts: DhcpOptions,
 }
 
-impl Decodable<'_> for IATA {
+impl Decodable for IATA {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(IATA {
             id: decoder.read_u32()?,
@@ -363,7 +363,7 @@ pub struct IANA {
     pub opts: DhcpOptions,
 }
 
-impl Decodable<'_> for IANA {
+impl Decodable for IANA {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(IANA {
             id: decoder.read_u32()?,
@@ -385,7 +385,7 @@ pub struct IAPD {
     pub opts: DhcpOptions,
 }
 
-impl Decodable<'_> for IAPD {
+impl Decodable for IAPD {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(IAPD {
             id: decoder.read_u32()?,
@@ -408,7 +408,7 @@ pub struct IAPDPrefix {
     pub opts: DhcpOptions,
 }
 
-impl Decodable<'_> for IAPDPrefix {
+impl Decodable for IAPDPrefix {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(IAPDPrefix {
             preferred_lifetime: decoder.read_u32()?,
@@ -433,7 +433,7 @@ pub struct IAAddr {
     pub opts: DhcpOptions,
 }
 
-impl Decodable<'_> for IAAddr {
+impl Decodable for IAAddr {
     fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
         Ok(IAAddr {
             addr: decoder.read::<16>()?.into(),
@@ -473,7 +473,7 @@ impl UnknownOption {
     }
 }
 
-impl Decodable<'_> for DhcpOptions {
+impl Decodable for DhcpOptions {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         let mut opts = Vec::new();
         while let Ok(opt) = DhcpOption::decode(decoder) {
@@ -489,7 +489,7 @@ impl Encodable for DhcpOptions {
     }
 }
 
-impl Decodable<'_> for DhcpOption {
+impl Decodable for DhcpOption {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         let code = decoder.read_u16()?.into();
         let len = decoder.read_u16()? as usize;


### PR DESCRIPTION
Moving the lifetime into Decodable makes it much more restrictive when actually using `<'a, T: Decodable<'a>`. `Opt` is an internal type so it doesn't _need_ to implement the trait.