### PR TITLE
Draft: move lifetime to Decodable trait

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,12 +11,26 @@ use std::{
 };
 
 /// A trait for types which are serializable to and from DHCP binary formats
-pub trait Decodable: Sized {
+///
+/// If decoding a type generically, you may need to use higher rank trait bounds:
+/// ```
+/// use dhcproto::{Decodable, Decoder, error::DecodeResult};
+///
+/// struct Msg<T> { msg: T }
+///
+/// impl<T: for<'a> Decodable<'a>> Msg<T> {
+///     fn new(buf: Vec<u8>) -> DecodeResult<Self> {
+///         let mut dec = Decoder::new(&buf);
+///         Ok(Self { msg: T::decode(&mut dec)? })
+///     }
+/// }
+/// ```
+pub trait Decodable<'a>: Sized {
     /// Read the type from the stream
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self>;
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self>;
 
     /// Returns the object in binary form
-    fn from_bytes(bytes: &[u8]) -> DecodeResult<Self> {
+    fn from_bytes(bytes: &'a [u8]) -> DecodeResult<Self> {
         let mut decoder = Decoder::new(bytes);
         Self::decode(&mut decoder)
     }

--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -55,8 +55,8 @@ impl From<Flags> for u16 {
     }
 }
 
-impl Decodable for Flags {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for Flags {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(decoder.read_u16()?.into())
     }
 }

--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -141,8 +141,8 @@ impl From<HType> for u8 {
     }
 }
 
-impl Decodable for HType {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for HType {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(decoder.read_u8()?.into())
     }
 }

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -455,8 +455,8 @@ impl Message {
     }
 }
 
-impl Decodable for Message {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for Message {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(Message {
             opcode: Opcode::decode(decoder)?,
             htype: decoder.read_u8()?.into(),

--- a/src/v4/opcode.rs
+++ b/src/v4/opcode.rs
@@ -18,14 +18,14 @@ pub enum Opcode {
     Unknown(u8),
 }
 
-impl Decodable for Opcode {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for Opcode {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(decoder.read_u8()?.into())
     }
 }
 
 impl Encodable for Opcode {
-    fn encode(&self, e: &'_ mut Encoder<'_>) -> EncodeResult<()> {
+    fn encode(&self, e: &mut Encoder<'_>) -> EncodeResult<()> {
         e.write_u8((*self).into())
     }
 }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -156,8 +156,8 @@ impl DhcpOptions {
     }
 }
 
-impl Decodable for DhcpOptions {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for DhcpOptions {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         // represented as a vector in the actual message
         let mut opts = HashMap::new();
         // should we error the whole parser if we fail to parse an
@@ -979,9 +979,9 @@ fn decode_inner(
     })
 }
 
-impl Decodable for DhcpOption {
+impl<'a> Decodable<'a> for DhcpOption {
     #[inline]
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         #[derive(Debug)]
         struct Opt<'a> {
             code: u8,
@@ -998,6 +998,8 @@ impl Decodable for DhcpOption {
 
                 decode_inner(code, opt_decoder.buffer().len(), &mut opt_decoder)
             }
+        }
+        impl<'a> Decodable<'a> for Opt<'a> {
             // can't implement Decodable b/c of lifetime issues
             fn decode(dec: &mut Decoder<'a>) -> DecodeResult<Self> {
                 // TODO: necessary to call u8::from_be_bytes?
@@ -1010,7 +1012,7 @@ impl Decodable for DhcpOption {
         use DhcpOption::*;
         // read the code first, determines the variant
         // pad|end have no length, so we can't read len up here
-        let mut last: Option<Opt<'_>> = None;
+        let mut last: Option<Opt<'a>> = None;
         while let Ok(code) = decoder.peek_u8() {
             match code.into() {
                 OptionCode::End => {
@@ -1427,8 +1429,8 @@ impl UnknownOption {
     }
 }
 
-impl Decodable for UnknownOption {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for UnknownOption {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         let code = decoder.read_u8()?;
         let length = decoder.read_u8()?;
         let bytes = decoder.read_slice(length as usize)?.to_vec();

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -74,8 +74,8 @@ impl RelayAgentInformation {
     }
 }
 
-impl Decodable for RelayAgentInformation {
-    fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
+impl<'a> Decodable<'a> for RelayAgentInformation {
+    fn decode(d: &mut crate::Decoder<'a>) -> super::DecodeResult<Self> {
         let mut opts = HashMap::new();
         while let Ok(opt) = RelayInfo::decode(d) {
             opts.insert(RelayCode::from(&opt), opt);
@@ -121,8 +121,8 @@ pub enum RelayInfo {
     // VirtualSubnetControl(u8),
 }
 
-impl Decodable for RelayInfo {
-    fn decode(d: &mut crate::Decoder<'_>) -> super::DecodeResult<Self> {
+impl<'a> Decodable<'a> for RelayInfo {
+    fn decode(d: &mut crate::Decoder<'a>) -> super::DecodeResult<Self> {
         use RelayInfo::*;
         // read the code first, determines the variant
         Ok(match d.read_u8()?.into() {

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -330,8 +330,8 @@ impl From<MessageType> for u8 {
     }
 }
 
-impl Decodable for Message {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for Message {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(Message {
             msg_type: decoder.read_u8()?.into(),
             xid: decoder.read::<3>()?,

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -141,7 +141,7 @@ pub struct UserClass {
 }
 
 #[inline]
-fn decode_data(decoder: &'_ mut Decoder<'_>) -> Vec<Vec<u8>> {
+fn decode_data(decoder: &mut Decoder<'_>) -> Vec<Vec<u8>> {
     let mut data = Vec::new();
     while let Ok(len) = decoder.read_u16() {
         // if we can read the len and the string
@@ -269,8 +269,8 @@ pub struct Authentication {
     pub info: Vec<u8>,
 }
 
-impl Decodable for Authentication {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for Authentication {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         let len = decoder.buffer().len();
         Ok(Authentication {
             proto: decoder.read_u8()?,
@@ -316,8 +316,8 @@ pub struct ORO {
     pub opts: Vec<OptionCode>,
 }
 
-impl Decodable for ORO {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for ORO {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         let len = decoder.buffer().len();
         Ok(ORO {
             opts: {
@@ -343,8 +343,8 @@ pub struct IATA {
     pub opts: DhcpOptions,
 }
 
-impl Decodable for IATA {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for IATA {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(IATA {
             id: decoder.read_u32()?,
             opts: DhcpOptions::decode(decoder)?,
@@ -363,8 +363,8 @@ pub struct IANA {
     pub opts: DhcpOptions,
 }
 
-impl Decodable for IANA {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for IANA {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(IANA {
             id: decoder.read_u32()?,
             t1: decoder.read_u32()?,
@@ -385,8 +385,8 @@ pub struct IAPD {
     pub opts: DhcpOptions,
 }
 
-impl Decodable for IAPD {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for IAPD {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(IAPD {
             id: decoder.read_u32()?,
             t1: decoder.read_u32()?,
@@ -408,8 +408,8 @@ pub struct IAPDPrefix {
     pub opts: DhcpOptions,
 }
 
-impl Decodable for IAPDPrefix {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for IAPDPrefix {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(IAPDPrefix {
             preferred_lifetime: decoder.read_u32()?,
             valid_lifetime: decoder.read_u32()?,
@@ -433,8 +433,8 @@ pub struct IAAddr {
     pub opts: DhcpOptions,
 }
 
-impl Decodable for IAAddr {
-    fn decode(decoder: &'_ mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for IAAddr {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         Ok(IAAddr {
             addr: decoder.read::<16>()?.into(),
             preferred_life: decoder.read_u32()?,
@@ -473,8 +473,8 @@ impl UnknownOption {
     }
 }
 
-impl Decodable for DhcpOptions {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for DhcpOptions {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         let mut opts = Vec::new();
         while let Ok(opt) = DhcpOption::decode(decoder) {
             opts.push(opt);
@@ -484,13 +484,13 @@ impl Decodable for DhcpOptions {
 }
 
 impl Encodable for DhcpOptions {
-    fn encode(&self, e: &'_ mut Encoder<'_>) -> EncodeResult<()> {
+    fn encode(&self, e: &mut Encoder<'_>) -> EncodeResult<()> {
         self.0.iter().try_for_each(|opt| opt.encode(e))
     }
 }
 
-impl Decodable for DhcpOption {
-    fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
+impl<'a> Decodable<'a> for DhcpOption {
+    fn decode(decoder: &mut Decoder<'a>) -> DecodeResult<Self> {
         let code = decoder.read_u16()?.into();
         let len = decoder.read_u16()? as usize;
         Ok(match code {
@@ -573,7 +573,7 @@ impl Decodable for DhcpOption {
     }
 }
 impl Encodable for DhcpOption {
-    fn encode(&self, e: &'_ mut Encoder<'_>) -> EncodeResult<()> {
+    fn encode(&self, e: &mut Encoder<'_>) -> EncodeResult<()> {
         let code: OptionCode = self.into();
         e.write_u16(code.into())?;
         match self {


### PR DESCRIPTION
Had initially kept the bound on `decode` fn, but it's strictly less expressive because you can't impl Decodable on types that contain references (like the internal Opt<'a>). Realized that HRTBs will help when using the type generically, so dropped an example in there.

I waffled on this a bit, master has removed then added the lifetime bound in the trait recently. Although none of those changes have actually been published.