### PR TITLE
v4: add relay opt at end of opts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- relay agent info will be added before END opt if present [see here](https://datatracker.ietf.org/doc/html/rfc3046#section-2.1)
+
 ## [0.8.0]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "dhcproto"
-version = "0.8.0"
+version = "0.9.0-alpha"
 dependencies = [
  "criterion",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dhcproto"
-version = "0.8.0"
+version = "0.9.0-alpha"
 authors = ["Ian Laidlaw <ilaidlaw@bluecatnetworks.com>", "Evan Cameron <cameron.evan@gmail.com>"]
 edition = "2021"
 description = """


### PR DESCRIPTION
relay agent information is supposed to be added
at the end of the buffer. So, in `encode` if it is
present we filter it out and add it at the end