### PR TITLE
v6: sorted DhcpOptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `PartialOrd`/`Ord` impls for `v4::DhcpOption`/`v6::DhcpOption`/`v4::OptionCode`/`v6::OptionCode`
+- `v6::DhcpOptions` methods `*_all`
+
+### Changed
+
+- internally, v6 DhcpOptions are now kept sorted by OptionCode (may become `HashMap<_, Vec<_>>` in future)
+
 ### Fixed
 
 - relay agent info will be added before END opt if present [see here](https://datatracker.ietf.org/doc/html/rfc3046#section-2.1)

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -367,6 +367,18 @@ pub enum OptionCode {
     End,
 }
 
+impl PartialOrd for OptionCode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OptionCode {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
+    }
+}
+
 impl From<u8> for OptionCode {
     fn from(n: u8) -> Self {
         use OptionCode::*;
@@ -702,6 +714,18 @@ pub enum DhcpOption {
     Unknown(UnknownOption),
     /// 255 End
     End,
+}
+
+impl PartialOrd for DhcpOption {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DhcpOption {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        OptionCode::from(self).cmp(&OptionCode::from(other))
+    }
 }
 
 /// Architecture name from - <https://www.rfc-editor.org/rfc/rfc4578.html>

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -15,7 +15,7 @@
 //! let mut msg = v6::Message::new(v6::MessageType::Solicit);
 //! // set an option
 //! msg.opts_mut()
-//!     .push(v6::DhcpOption::ClientId(duid));
+//!     .insert(v6::DhcpOption::ClientId(duid));
 //!
 //! // now encode to bytes
 //! let mut buf = Vec::new();
@@ -374,7 +374,6 @@ mod tests {
         println!("{:?}", input);
         // no PAD bytes or hashmap with ipv6 so the lens will be exact
         assert_eq!(buf.len(), input.len());
-        assert_eq!(buf, input);
         // decode again
         let res = Message::decode(&mut Decoder::new(&buf))?;
         // check Messages are equal after decoding/encoding


### PR DESCRIPTION
Duplicates are allowed in the v6 options list. I considered changing the representation to `HashMap<_, Vec<_>>` or even `SmallVec<[_; 1]>`. Hard to know without benchmarks what would be better.

At the moment, I thought that duplicates would be rare, so an extra alloc per insert is probably not worth it. `SmallVec` would keep things on the stack but without a benchmark it feels premature. I opted instead to just leave it as a list and maintain sorted state internally. 
