### PR TITLE
v4: add option 121

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ version = "0.9.0-alpha"
 dependencies = [
  "criterion",
  "hex",
+ "ipnet",
  "rand",
  "serde",
  "serde_json",
@@ -324,6 +325,9 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 hex = "0.4.3"
 trust-dns-proto = { version = "0.21.2", default-features = false }
 url = "2.2.2"
+ipnet = "2.5"
 
 [features]
 default = []
-serde = ["dep:serde", "url/serde"]
+serde = ["dep:serde", "url/serde", "ipnet/serde"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,13 +9,6 @@ pub type DecodeResult<T> = Result<T, DecodeError>;
 /// Returned from types that decode
 #[derive(Error, Debug)]
 pub enum DecodeError {
-    /// encountered end of buffer
-    #[error("decoder ran out of bytes to read on byte {index}")]
-    EndOfBuffer {
-        /// index in buffer
-        index: usize,
-    },
-
     /// add overflow
     #[error("decoder checked_add failed")]
     AddOverflow,

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -1026,7 +1026,10 @@ fn decode_inner(
 
             let mut route_dec = Decoder::new(decoder.read_slice(len)?);
             while let Ok(prefix_len) = route_dec.read_u8() {
-                debug_assert!(prefix_len <= 32);
+                if prefix_len > 32 {
+                    break;
+                }
+
                 // Significant bytes to hold the prefix
                 let sig_bytes = (prefix_len as usize + 7) / 8;
 


### PR DESCRIPTION
This PR adds support for DHCP option 121 (Classless Static Routes) for DHCPv4 as described in RFC3442.

This option allows a DHCP server to send a whole routing table to a client. It is also sometimes used instead of DHCP option 3 (Router) in some environments.

Related to this option, this PR adds support for merging some consecutive DHCP options that contains lists of items, option 121 being a prime example. The previous behavior was to replace the previously parsed option when encountering it multiple times in a packet; however it may be useful to specify options multiple times when they are pretty large (e.g. large routing tables).