### PR TITLE
v4: adds methods to clear sname/fname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `v6::Message` `Display` impl
 - `v6::RelayMessage`
 - `v4::NISServerAddr` added to options
+- `v4::Message::clear_sname`/`clear_fname` added
 - dhcpv4 opt client fqdn added. uses trust-dns-proto's `Domain` type to decode the domain
 
 ### Changed

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -393,6 +393,10 @@ impl Message {
     pub fn fname(&self) -> Option<&[u8]> {
         self.fname.as_deref()
     }
+    /// Clear the `fname` header field.
+    pub fn clear_fname(&mut self) {
+        self.fname = None;
+    }
     /// Get a reference to the message's fname, UTF-8 encoded
     pub fn fname_str(&self) -> Option<Result<&str, Utf8Error>> {
         self.fname().map(std::str::from_utf8)
@@ -417,6 +421,10 @@ impl Message {
     /// Get a reference to the message's sname. No particular encoding is enforced.
     pub fn sname(&self) -> Option<&[u8]> {
         self.sname.as_deref()
+    }
+    /// Clear the `sname` header field.
+    pub fn clear_sname(&mut self) {
+        self.sname = None;
     }
     /// Get a reference to the message's sname as a UTF-8 encoded string.
     pub fn sname_str(&self) -> Option<Result<&str, Utf8Error>> {


### PR DESCRIPTION
It's possible to call `set_fname(b"")` but that will represent the `Message` field as `Some([])` rather than `None`. The generated packet will be the same but may as well just provide these methods.