### PR TITLE
Client FQDN

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -158,7 +158,7 @@ impl<'a> Decoder<'a> {
         if length % 4 != 0 {
             return Err(DecodeError::NotEnoughBytes);
         }
-        let ips = self.read_slice(length as usize)?;
+        let ips = self.read_slice(length)?;
         Ok(ips
             .chunks(4)
             .map(|bytes| [bytes[0], bytes[1], bytes[2], bytes[3]].into())
@@ -171,7 +171,7 @@ impl<'a> Decoder<'a> {
         if length % 16 != 0 {
             return Err(DecodeError::NotEnoughBytes);
         }
-        let ips = self.read_slice(length as usize)?;
+        let ips = self.read_slice(length)?;
         // type annotations needed below
         Ok(ips
             .chunks(16)
@@ -185,7 +185,7 @@ impl<'a> Decoder<'a> {
         if length % 8 != 0 {
             return Err(DecodeError::NotEnoughBytes);
         }
-        let ips = self.read_slice(length as usize)?;
+        let ips = self.read_slice(length)?;
         Ok(ips
             .chunks(8)
             .map(|bytes| {

--- a/src/v4/bulk_query.rs
+++ b/src/v4/bulk_query.rs
@@ -18,7 +18,7 @@ impl fmt::Debug for DataSourceFlags {
 
 impl fmt::Display for DataSourceFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/v4/flags.rs
+++ b/src/v4/flags.rs
@@ -24,7 +24,7 @@ impl fmt::Debug for Flags {
 
 impl fmt::Display for Flags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/v4/fqdn.rs
+++ b/src/v4/fqdn.rs
@@ -3,9 +3,64 @@ use std::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::Domain;
+
+/// A client FQDN
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ClientFQDN {
+    pub(crate) flags: FqdnFlags,
+    pub(crate) r1: u8,
+    pub(crate) r2: u8,
+    pub(crate) domain: Domain,
+}
+
+impl ClientFQDN {
+    // creates a new client fqdn setting the rcode1/rcode2 fields to 255
+    pub fn new(flags: FqdnFlags, domain: Domain) -> Self {
+        Self {
+            flags,
+            r1: 0xFF,
+            r2: 0xFF,
+            domain,
+        }
+    }
+    pub fn flags(&self) -> FqdnFlags {
+        self.flags
+    }
+    pub fn set_flags(&mut self, flags: FqdnFlags) -> &mut Self {
+        self.flags = flags;
+        self
+    }
+    pub fn r1(&self) -> u8 {
+        self.r1
+    }
+    pub fn set_r1(&mut self, rcode1: u8) -> &mut Self {
+        self.r1 = rcode1;
+        self
+    }
+    pub fn r2(&self) -> u8 {
+        self.r2
+    }
+    pub fn set_r2(&mut self, rcode2: u8) -> &mut Self {
+        self.r2 = rcode2;
+        self
+    }
+    pub fn domain(&self) -> &Domain {
+        &self.domain
+    }
+    pub fn set_domain(&mut self, domain: Domain) -> &mut Self {
+        self.domain = domain;
+        self
+    }
+    pub fn domain_mut(&mut self) -> &mut Domain {
+        &mut self.domain
+    }
+}
+
 /// Represents available flags on message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Default, Clone, PartialEq, Eq)]
+#[derive(Copy, Default, Clone, PartialEq, Eq, Hash)]
 pub struct FqdnFlags(u8);
 
 impl fmt::Debug for FqdnFlags {

--- a/src/v4/fqdn.rs
+++ b/src/v4/fqdn.rs
@@ -89,11 +89,14 @@ impl FqdnFlags {
     pub fn n(&self) -> bool {
         (self.0 & 0x08) > 0
     }
-    /// set the n bit, whether the server SHOULD NOT perform any DNS updates.
-    /// clients set this to 0 to indicate the server SHOULD update, and 1
-    /// to indicate it SHOULD NOT
-    pub fn set_n(mut self) -> Self {
-        self.0 |= 0x08;
+    /// set the n bit, if true will also set the s bit to false.
+    pub fn set_n(mut self, bit: bool) -> Self {
+        if bit {
+            self.0 |= 0x08; // 1000
+            self.set_s(false);
+        } else {
+            self.0 &= 0x07; // 0111
+        }
         self
     }
     /// get the status of the e flag
@@ -101,8 +104,12 @@ impl FqdnFlags {
         (self.0 & 0x04) > 0
     }
     /// set the e bit
-    pub fn set_e(mut self) -> Self {
-        self.0 |= 0x04;
+    pub fn set_e(mut self, bit: bool) -> Self {
+        if bit {
+            self.0 |= 0x04; // 0100
+        } else {
+            self.0 &= 0x0b; // 1011
+        }
         self
     }
     /// get the status of the o flag
@@ -110,8 +117,12 @@ impl FqdnFlags {
         (self.0 & 0x02) > 0
     }
     /// set the o bit
-    pub fn set_o(mut self) -> Self {
-        self.0 |= 0x02;
+    pub fn set_o(mut self, bit: bool) -> Self {
+        if bit {
+            self.0 |= 0x02; // 0010
+        } else {
+            self.0 &= 0x0d; // 1101
+        }
         self
     }
     /// get the status of the s flag
@@ -119,8 +130,12 @@ impl FqdnFlags {
         (self.0 & 0x01) > 0
     }
     /// set the s bit. Indicates whether the server should perform an A RR update
-    pub fn set_s(mut self) -> Self {
-        self.0 |= 0x01;
+    pub fn set_s(mut self, bit: bool) -> Self {
+        if bit {
+            self.0 |= 0x01; // 0001
+        } else {
+            self.0 &= 0x0e; // 1110
+        }
         self
     }
 }
@@ -144,21 +159,26 @@ mod tests {
     fn test_fqdn_flags() {
         let flag = FqdnFlags::default();
         assert_eq!(flag.0, 0);
-        let flag = flag.set_n();
+        let flag = flag.set_n(true);
         assert!(flag.n());
         assert_eq!(flag.0, 0x08);
+        let flag = flag.set_n(false);
+        assert!(!flag.n());
+        assert_eq!(flag.0, 0x00);
 
-        let flag = FqdnFlags::new(0x40).set_s();
+        let flag = FqdnFlags::new(0x40).set_s(true);
         assert!(!flag.e());
         assert!(flag.s());
         assert!(!flag.n());
         assert!(!flag.o());
         assert_eq!(flag.0, 0x41);
-        let flag = flag.set_e();
+        let flag = flag.set_e(true);
         assert!(flag.e() && flag.s());
 
-        let flag = FqdnFlags::default().set_e();
+        let flag = FqdnFlags::default().set_e(true);
         assert!(flag.e());
         assert_eq!(flag.0, 0x04);
+        let flag = flag.set_s(true);
+        assert_eq!(flag.0, 0x05);
     }
 }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -977,7 +977,7 @@ fn decode_inner(
         OptionCode::CaptivePortal => CaptivePortal(decoder.read_str(len)?.parse()?),
         OptionCode::SubnetSelection => SubnetSelection(decoder.read_ipv4(len)?),
         OptionCode::DomainSearch => {
-            let mut name_decoder = BinDecoder::new(decoder.read_slice(len as usize)?);
+            let mut name_decoder = BinDecoder::new(decoder.read_slice(len)?);
             let mut names = Vec::new();
             while let Ok(name) = Name::read(&mut name_decoder) {
                 names.push(Domain(name));
@@ -1017,7 +1017,7 @@ fn decode_inner(
             let rcode1 = decoder.read_u8()?;
             let rcode2 = decoder.read_u8()?;
 
-            let mut name_decoder = BinDecoder::new(decoder.read_slice(len as usize - 3)?);
+            let mut name_decoder = BinDecoder::new(decoder.read_slice(len - 3)?);
             let name = Name::read(&mut name_decoder)?;
             ClientFQDN(fqdn::ClientFQDN {
                 flags,
@@ -1868,7 +1868,7 @@ mod tests {
     fn test_client_fqdn() -> Result<()> {
         test_opt(
             DhcpOption::ClientFQDN(fqdn::ClientFQDN {
-                flags: fqdn::FqdnFlags::default().set_e(),
+                flags: fqdn::FqdnFlags::default().set_e(true),
                 r1: 0,
                 r2: 0,
                 domain: Domain(Name::from_str("www.google.com.").unwrap()),

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -230,7 +230,7 @@ impl fmt::Debug for RelayFlags {
 
 impl fmt::Display for RelayFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -608,7 +608,7 @@ impl Decodable for DhcpOption {
                 DhcpOption::IAPrefix(IAPrefix::decode(&mut dec)?)
             }
             OptionCode::DomainSearchList => {
-                let mut name_decoder = BinDecoder::new(decoder.read_slice(len as usize)?);
+                let mut name_decoder = BinDecoder::new(decoder.read_slice(len)?);
                 let mut names = Vec::new();
                 while let Ok(name) = Name::read(&mut name_decoder) {
                     names.push(Domain(name));


### PR DESCRIPTION
Adds some convenience methods to client fqdn. The `FqdnFlags` didn't have a way to turn off either without just recreating the flag set, so the methods have been changed to toggle `set_x` and take `true`/`false`.