### PR TITLE
fix(dhcpv6): fix panic when accessing empty DhcpOptions

### DIFF
--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -818,6 +818,10 @@ where
     T: Ord,
     F: Fn(&T) -> Ordering,
 {
+    if arr.is_empty() {
+        return None;
+    }
+
     let mut l = 0;
     let mut r = arr.len() - 1;
     while l <= r {
@@ -846,6 +850,10 @@ where
     T: Ord,
     F: Fn(&T) -> Ordering,
 {
+    if arr.is_empty() {
+        return None;
+    }
+
     let n = arr.len();
     let mut l = 0;
     let mut r = n - 1;


### PR DESCRIPTION
When the `DhcpOptions` struct has nothing in it, the code panics (in debug mode) due to an underflowing substraction (`len - 1`), or wraps and takes ages in release mode. This can happen when getting suboptions of options. My case:

```rust
let msg: dhcproto::v6::Message = .......;
if let Some(DhcpOption::IANA(IANA { id, opts, ... })) = msg.opts().get(OptionCode::IANA) {
    if let Some(DhcpOption::IAAddr(addr)) = opts.get(OptionCode::IAAddr) { // .get panics
        //
    }
}
```

This crashes using `dhclient -6` with the following stacktrace:

```
thread 'main' panicked at 'attempt to subtract with overflow', /home/tuetuopay/.cargo/git/checkouts/dhcproto-5f8e80f362f839f6/406cd43/src/v6/options.rs:822:17
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at ./rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at ./rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:48:5
   3: dhcproto::v6::options::first
             at ./home/tuetuopay/.cargo/git/checkouts/dhcproto-5f8e80f362f839f6/406cd43/src/v6/options.rs:822:17
   4: dhcproto::v6::options::DhcpOptions::get
             at ./home/tuetuopay/.cargo/git/checkouts/dhcproto-5f8e80f362f839f6/406cd43/src/v6/options.rs:36:21
```

The fix is to add an early exit to the `first` and `last` functions if the options list is empty.