### PR TITLE
Return AgentRemoteId after decoding, instead of AgentCircuitId

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -102,7 +102,7 @@ impl<'a> Decoder<'a> {
         let bytes = self.read::<MAX>()?;
         let nul_idx = bytes.iter().position(|&b| b == 0);
         match nul_idx {
-            Some(n) if n == 0 => Ok(None),
+            Some(0) => Ok(None),
             Some(n) => Ok(Some(CStr::from_bytes_with_nul(&bytes[..=n])?.to_owned())),
             // TODO: error?
             None => Ok(None),
@@ -113,7 +113,7 @@ impl<'a> Decoder<'a> {
         let bytes = self.read::<MAX>()?;
         let nul_idx = bytes.iter().position(|&b| b == 0);
         match nul_idx {
-            Some(n) if n == 0 => Ok(None),
+            Some(0) => Ok(None),
             Some(n) => Ok(Some(bytes[..=n].to_vec())),
             // TODO: error?
             None => Ok(None),

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -134,7 +134,7 @@ impl Decodable for RelayInfo {
             RelayCode::AgentRemoteId => {
                 let len = d.read_u8()? as usize;
                 let data = d.read_slice(len)?.to_vec();
-                AgentCircuitId(data)
+                AgentRemoteId(data)
             }
             RelayCode::DocsisDeviceClass => {
                 let _ = d.read_u8()?;
@@ -410,6 +410,15 @@ mod tests {
         test_opt(
             RelayInfo::AgentCircuitId(vec![0, 1, 2, 3, 4]),
             vec![1, 5, 0, 1, 2, 3, 4],
+        )?;
+
+        Ok(())
+    }
+    #[test]
+    fn test_remote() -> Result<()> {
+        test_opt(
+            RelayInfo::AgentRemoteId(vec![0, 1, 2, 3, 4]),
+            vec![2, 5, 0, 1, 2, 3, 4],
         )?;
 
         Ok(())


### PR DESCRIPTION
During decoding agent remote id(2) in option82, instead of returning AgentRemoteId, AgentCircuitId is returned. This fix returns AgentRemoteId after decoding it.