### PR TITLE
modify v6 Htype

### DIFF
--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -41,8 +41,6 @@ pub enum HType {
     SMDS,
     /// 15 FrameRelay
     FrameRelay,
-    /// 16,19,21 ATM
-    ATM,
     /// 17 HDLC
     HDLC,
     /// 18 FibreChannel
@@ -53,36 +51,20 @@ pub enum HType {
     MilStd188220,
     /// 23 Metricom
     Metricom,
-    /// 24 IEEE1394.1995
-    IEEE13941995,
     /// 25 MAPOS
     MAPOS,
     /// 26 Twinaxial
     Twinaxial,
-    /// 27 EUI64
-    EUI64,
-    /// 28 HIPARP
-    HIPARP,
-    /// 29 IP and ARP over ISO 7816-3
-    IPandARPoverISO78163,
     /// 30 ARPSec
     ARPSec,
     /// 31 IPsec tunnel
     IPsecTunnel,
     /// 32 Infiniband
     Infiniband,
-    /// 33 TIA-102 Project 25 Common Air Interface (CAI)
-    CAI,
     /// 34 WeigandInt
     WiegandInt,
     /// 35 PureIP
     PureIP,
-    /// 36 HW_EXP1
-    HWExp1,
-    /// 37 HFI
-    HFI,
-    /// 38 Unified BUS(UB),
-    UB,
     /// Unknown or not yet implemented htype
     Unknown(u8),
 }
@@ -106,27 +88,18 @@ impl From<u8> for HType {
             13 => Ultralink,
             14 => SMDS,
             15 => FrameRelay,
-            16 | 19 | 21 => ATM,
             17 => HDLC,
             18 => FibreChannel,
             20 => SerialLine,
             22 => MilStd188220,
             23 => Metricom,
-            24 => IEEE13941995,
             25 => MAPOS,
             26 => Twinaxial,
-            27 => EUI64,
-            28 => HIPARP,
-            29 => IPandARPoverISO78163,
             30 => ARPSec,
             31 => IPsecTunnel,
             32 => Infiniband,
-            33 => CAI,
             34 => WiegandInt,
             35 => PureIP,
-            36 => HWExp1,
-            37 => HFI,
-            38 => UB,
             n => Unknown(n),
         }
     }
@@ -151,27 +124,18 @@ impl From<HType> for u8 {
             H::Ultralink => 13,
             H::SMDS => 14,
             H::FrameRelay => 15,
-            H::ATM => 19, // !!! 16,19,21 are all possible. 19 is chosen according to RFC2225
             H::HDLC => 17,
             H::FibreChannel => 18,
             H::SerialLine => 20,
             H::MilStd188220 => 22,
             H::Metricom => 23,
-            H::IEEE13941995 => 24,
             H::MAPOS => 25,
             H::Twinaxial => 26,
-            H::EUI64 => 27,
-            H::HIPARP => 28,
-            H::IPandARPoverISO78163 => 29,
             H::ARPSec => 30,
             H::IPsecTunnel => 31,
             H::Infiniband => 32,
-            H::CAI => 33,
             H::WiegandInt => 34,
             H::PureIP => 35,
-            H::HWExp1 => 36,
-            H::HFI => 37,
-            H::UB => 38,
             H::Unknown(n) => n,
         }
     }

--- a/src/v6/duid.rs
+++ b/src/v6/duid.rs
@@ -3,7 +3,8 @@ use std::net::Ipv6Addr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{v4::HType, Encoder};
+use crate::v6::HType;
+use crate::Encoder;
 
 /// Duid helper type
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -17,7 +18,7 @@ impl Duid {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
         e.write_u16(1).unwrap(); // duid type
-        e.write_u16(u8::from(htype) as u16).unwrap();
+        e.write_u16(u16::from(htype)).unwrap();
         e.write_u32(time).unwrap();
         e.write_u128(addr.into()).unwrap();
         Self(buf)
@@ -36,7 +37,7 @@ impl Duid {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
         e.write_u16(3).unwrap(); // duid type
-        e.write_u16(u8::from(htype) as u16).unwrap();
+        e.write_u16(u16::from(htype)).unwrap();
         e.write_u128(addr.into()).unwrap();
         Self(buf)
     }

--- a/src/v6/htype.rs
+++ b/src/v6/htype.rs
@@ -1,3 +1,4 @@
+/// In DHCPv6, the Hardware Types are expanded from u8 to u16, referring to https://www.iana.org/assignments/arp-parameters/arp-parameters.xhtml for implementation.
 use crate::{
     decoder::{Decodable, Decoder},
     encoder::{Encodable, Encoder},
@@ -83,12 +84,17 @@ pub enum HType {
     HFI,
     /// 38 Unified BUS(UB),
     UB,
+    /// 256 HW_EXP2
+    HWExp2,
+    /// 257 AEthernet
+    AEthernet,
+    /// 65535 Reserved
+    Reserved,
     /// Unknown or not yet implemented htype
-    Unknown(u8),
+    Unknown(u16),
 }
-
-impl From<u8> for HType {
-    fn from(n: u8) -> Self {
+impl From<u16> for HType {
+    fn from(n: u16) -> Self {
         use HType::*;
         match n {
             1 => Eth,
@@ -127,12 +133,15 @@ impl From<u8> for HType {
             36 => HWExp1,
             37 => HFI,
             38 => UB,
+            256 => HWExp2,
+            257 => AEthernet,
+            65535 => Reserved,
             n => Unknown(n),
         }
     }
 }
 
-impl From<HType> for u8 {
+impl From<HType> for u16 {
     fn from(n: HType) -> Self {
         use HType as H;
         match n {
@@ -151,7 +160,7 @@ impl From<HType> for u8 {
             H::Ultralink => 13,
             H::SMDS => 14,
             H::FrameRelay => 15,
-            H::ATM => 19, // !!! 16,19,21 are all possible. 19 is chosen according to RFC2225
+            H::ATM => 16, // !!! 16,19,21 are all possible. 19 is chosen according to RFC2225
             H::HDLC => 17,
             H::FibreChannel => 18,
             H::SerialLine => 20,
@@ -172,6 +181,9 @@ impl From<HType> for u8 {
             H::HWExp1 => 36,
             H::HFI => 37,
             H::UB => 38,
+            H::HWExp2 => 256,
+            H::AEthernet => 257,
+            H::Reserved => 65535,
             H::Unknown(n) => n,
         }
     }
@@ -179,12 +191,12 @@ impl From<HType> for u8 {
 
 impl Decodable for HType {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
-        Ok(decoder.read_u8()?.into())
+        Ok(decoder.read_u16()?.into())
     }
 }
 
 impl Encodable for HType {
     fn encode(&self, e: &mut Encoder<'_>) -> EncodeResult<()> {
-        e.write_u8((*self).into())
+        e.write_u16((*self).into())
     }
 }

--- a/src/v6/htype.rs
+++ b/src/v6/htype.rs
@@ -42,8 +42,6 @@ pub enum HType {
     SMDS,
     /// 15 FrameRelay
     FrameRelay,
-    /// 16,19,21 ATM
-    ATM,
     /// 17 HDLC
     HDLC,
     /// 18 FibreChannel
@@ -112,7 +110,6 @@ impl From<u16> for HType {
             13 => Ultralink,
             14 => SMDS,
             15 => FrameRelay,
-            16 | 19 | 21 => ATM,
             17 => HDLC,
             18 => FibreChannel,
             20 => SerialLine,
@@ -160,7 +157,6 @@ impl From<HType> for u16 {
             H::Ultralink => 13,
             H::SMDS => 14,
             H::FrameRelay => 15,
-            H::ATM => 16, // !!! 16,19,21 are all possible. 19 is chosen according to RFC2225
             H::HDLC => 17,
             H::FibreChannel => 18,
             H::SerialLine => 20,

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -53,6 +53,7 @@
 //! ```
 //!
 pub mod duid;
+mod htype;
 mod option_codes;
 mod options;
 mod oro_codes;
@@ -63,6 +64,7 @@ use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, fmt, net::Ipv6Addr};
 
 // re-export submodules from v6
+pub use self::htype::*;
 pub use self::option_codes::*;
 pub use self::options::*;
 pub use self::oro_codes::*;


### PR DESCRIPTION
Hello! I referred to the implementation of v4 htype and added support for v6 htype extended to u16. The following content includes:
(1) Add v6 support. I added the code for v6 htype under the v6 folder, most of which is the same as the code for v4 htype, which may be redundant. Is there a better solution?
(2) For the original v4 htype, I referred to https://www.iana.org/assignments/arp-parameters/arp-parameters.xhtml and made some supplements, and my questions can be found in #68.
