### PR TITLE
feat(dhcp6): implement `NTP_SERVER` options

### DIFF
--- a/src/v6/option_codes.rs
+++ b/src/v6/option_codes.rs
@@ -470,6 +470,7 @@ impl From<&DhcpOption> for OptionCode {
             O::IAPD(_) => OptionCode::IAPD,
             O::IAPrefix(_) => OptionCode::IAPrefix,
             O::InformationRefreshTime(_) => OptionCode::InformationRefreshTime,
+            O::NtpServer(_) => OptionCode::NtpServer,
             // SolMaxRt(_) => OptionCode::SolMaxRt,
             // InfMaxRt(_) => OptionCode::InfMaxRt,
             // LqQuery(_) => OptionCode::LqQuery,


### PR DESCRIPTION
Hello 😄,

I'm trying to implement NTP server advertisement via dhcpv6 server created from this lib but the option is not officially supported.
Here's an implementation of the NTP option for dhcpv6.