### PR TITLE
`Encoder::buffer_filled` and `::len_filled`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -17,7 +17,10 @@ pub trait Encodable {
 
 /// Encoder type, holds a mut ref to a buffer
 /// that it will write data to and an offset
-/// of the next position to write
+/// of the next position to write.
+/// 
+/// This will start writing from the beginning of the buffer, *not* from the end.
+/// The buffer will be grown as needed.
 #[derive(Debug)]
 pub struct Encoder<'a> {
     buffer: &'a mut Vec<u8>,
@@ -33,6 +36,16 @@ impl<'a> Encoder<'a> {
     /// Get a reference to the underlying buffer
     pub fn buffer(&self) -> &[u8] {
         self.buffer
+    }
+
+    /// Returns the slice of the underlying buffer that has been filled.
+    pub fn buffer_filled(&self) -> &[u8] {
+        &self.buffer[..self.offset]
+    }
+
+    /// Returns the number of bytes that have been written to the buffer.
+    pub fn len_filled(&self) -> usize {
+        self.offset
     }
 
     /// write bytes to buffer


### PR DESCRIPTION
This PR adds two methods to the `Encoder`:

 - `buffer_filled`: returns only the portion of the buffer that was written to, i.e. the serialized message.
 - `len_filled`: returns the number of bytes that have been written.

In my usecase I'm reusing a buffer for sending/receiving. I don't want to truncate the buffer to length 0, just to have to grow (and thus initialize) it later again. `Encoder` writes to the buffer from the beginning anyway and only grows it as needed. If the buffer was larger that the serialized message, the `buffer()` method will still return the whole buffer, including any garbage at the end of the buffer.

With `buffer_filled` and `len_filled` you can easily get a slice of the serialized message.