### PR TITLE
Fix DHCP option order not being preserved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.2",
  "textwrap",
 ]
 
@@ -201,6 +201,7 @@ dependencies = [
  "criterion",
  "dhcproto-macros",
  "hex",
+ "indexmap 2.4.0",
  "ipnet",
  "rand",
  "serde",
@@ -234,6 +235,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "form_urlencoded"
@@ -309,6 +316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +360,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "criterion",
  "dhcproto-macros",
  "hex",
- "indexmap 2.4.0",
+ "indexmap 2.6.0",
  "ipnet",
  "rand",
  "serde",
@@ -317,9 +317,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -365,12 +365,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+indexmap = "2.6.0"
 thiserror = "1.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -24,7 +25,6 @@ trust-dns-proto = { version = "0.22.0", default-features = false }
 url = "2.2.2"
 dhcproto-macros = { path = "./dhcproto-macros", version = "0.1.0" }
 ipnet = "2.5"
-indexmap = "2.4"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ trust-dns-proto = { version = "0.22.0", default-features = false }
 url = "2.2.2"
 dhcproto-macros = { path = "./dhcproto-macros", version = "0.1.0" }
 ipnet = "2.5"
+indexmap = "2.4"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-indexmap = "2.6.0"
+indexmap = { version = "2.6.0", features = ["serde"] }
 thiserror = "1.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -180,7 +180,7 @@ impl DhcpOptions {
     }
     /// remove option
     pub fn remove(&mut self, code: OptionCode) -> Option<DhcpOption> {
-        self.0.remove(&code)
+        self.0.shift_remove(&code)
     }
     /// insert a new [`DhcpOption`]
     ///

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, iter, net::Ipv4Addr};
+use std::{borrow::Cow, collections::BTreeMap, iter, net::Ipv4Addr};
 
 use crate::{
     decoder::{Decodable, Decoder},
@@ -155,7 +155,7 @@ dhcproto_macros::declare_codes!(
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct DhcpOptions(HashMap<OptionCode, DhcpOption>);
+pub struct DhcpOptions(BTreeMap<OptionCode, DhcpOption>);
 
 impl DhcpOptions {
     /// Create new [`DhcpOptions`]
@@ -276,7 +276,7 @@ impl DhcpOptions {
 
 impl IntoIterator for DhcpOptions {
     type Item = (OptionCode, DhcpOption);
-    type IntoIter = std::collections::hash_map::IntoIter<OptionCode, DhcpOption>;
+    type IntoIter = std::collections::btree_map::IntoIter<OptionCode, DhcpOption>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -288,21 +288,21 @@ impl FromIterator<DhcpOption> for DhcpOptions {
         DhcpOptions(
             iter.into_iter()
                 .map(|opt| ((&opt).into(), opt))
-                .collect::<HashMap<OptionCode, DhcpOption>>(),
+                .collect::<BTreeMap<OptionCode, DhcpOption>>(),
         )
     }
 }
 
 impl FromIterator<(OptionCode, DhcpOption)> for DhcpOptions {
     fn from_iter<T: IntoIterator<Item = (OptionCode, DhcpOption)>>(iter: T) -> Self {
-        DhcpOptions(iter.into_iter().collect::<HashMap<_, _>>())
+        DhcpOptions(iter.into_iter().collect::<BTreeMap<_, _>>())
     }
 }
 
 impl Decodable for DhcpOptions {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         // represented as a vector in the actual message
-        let mut opts = HashMap::new();
+        let mut opts = BTreeMap::new();
         // should we error the whole parser if we fail to parse an
         // option or just stop parsing options? -- here we will just stop
         while let Ok(opt) = DhcpOption::decode(decoder) {

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, collections::BTreeMap, iter, net::Ipv4Addr};
+use std::{borrow::Cow, iter, net::Ipv4Addr};
+
+use indexmap::IndexMap;
 
 use crate::{
     decoder::{Decodable, Decoder},
@@ -155,7 +157,7 @@ dhcproto_macros::declare_codes!(
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct DhcpOptions(BTreeMap<OptionCode, DhcpOption>);
+pub struct DhcpOptions(IndexMap<OptionCode, DhcpOption>);
 
 impl DhcpOptions {
     /// Create new [`DhcpOptions`]
@@ -276,7 +278,7 @@ impl DhcpOptions {
 
 impl IntoIterator for DhcpOptions {
     type Item = (OptionCode, DhcpOption);
-    type IntoIter = std::collections::btree_map::IntoIter<OptionCode, DhcpOption>;
+    type IntoIter = indexmap::map::IntoIter<OptionCode, DhcpOption>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -288,21 +290,21 @@ impl FromIterator<DhcpOption> for DhcpOptions {
         DhcpOptions(
             iter.into_iter()
                 .map(|opt| ((&opt).into(), opt))
-                .collect::<BTreeMap<OptionCode, DhcpOption>>(),
+                .collect::<IndexMap<OptionCode, DhcpOption>>(),
         )
     }
 }
 
 impl FromIterator<(OptionCode, DhcpOption)> for DhcpOptions {
     fn from_iter<T: IntoIterator<Item = (OptionCode, DhcpOption)>>(iter: T) -> Self {
-        DhcpOptions(iter.into_iter().collect::<BTreeMap<_, _>>())
+        DhcpOptions(iter.into_iter().collect::<IndexMap<_, _>>())
     }
 }
 
 impl Decodable for DhcpOptions {
     fn decode(decoder: &mut Decoder<'_>) -> DecodeResult<Self> {
         // represented as a vector in the actual message
-        let mut opts = BTreeMap::new();
+        let mut opts = IndexMap::new();
         // should we error the whole parser if we fail to parse an
         // option or just stop parsing options? -- here we will just stop
         while let Ok(opt) = DhcpOption::decode(decoder) {


### PR DESCRIPTION
Fixes #75 by introducing a data-structure that will preserve insertion order.
