### PR TITLE
Adjust hlen for case where chaddr length is greater than 16.

### DIFF
--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -613,6 +613,9 @@ mod tests {
         );
         msg.set_chaddr(&[0, 1, 2, 3, 4, 5]);
         assert_eq!(msg.chaddr().len(), 6);
+
+        msg.set_chaddr(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]);
+        assert_eq!(msg.chaddr().len(), 16);
         Ok(())
     }
 

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -289,12 +289,14 @@ impl Message {
     /// Set the message's chaddr. `chaddr` can only up to 16 bytes in length
     pub fn set_chaddr(&mut self, chaddr: &[u8]) -> &mut Self {
         let mut new_chaddr = [0; 16];
+        let mut new_chaddr_len = chaddr.len();
         if chaddr.len() >= 16 {
             new_chaddr.copy_from_slice(&chaddr[..16]);
+            new_chaddr_len = 16
         } else {
             new_chaddr[..chaddr.len()].copy_from_slice(chaddr);
         }
-        self.hlen = chaddr.len() as u8;
+        self.hlen = new_chaddr_len as u8;
         self.chaddr = new_chaddr;
         self
     }

--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -289,14 +289,13 @@ impl Message {
     /// Set the message's chaddr. `chaddr` can only up to 16 bytes in length
     pub fn set_chaddr(&mut self, chaddr: &[u8]) -> &mut Self {
         let mut new_chaddr = [0; 16];
-        let mut new_chaddr_len = chaddr.len();
+        self.hlen = chaddr.len() as u8;
         if chaddr.len() >= 16 {
             new_chaddr.copy_from_slice(&chaddr[..16]);
-            new_chaddr_len = 16
+            self.hlen = 16
         } else {
             new_chaddr[..chaddr.len()].copy_from_slice(chaddr);
         }
-        self.hlen = new_chaddr_len as u8;
         self.chaddr = new_chaddr;
         self
     }
@@ -614,7 +613,9 @@ mod tests {
         msg.set_chaddr(&[0, 1, 2, 3, 4, 5]);
         assert_eq!(msg.chaddr().len(), 6);
 
-        msg.set_chaddr(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]);
+        msg.set_chaddr(&[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        ]);
         assert_eq!(msg.chaddr().len(), 16);
         Ok(())
     }


### PR DESCRIPTION
One of our applications that is using this library ran into a panic:
```
panicked at /Users/andrew/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dhcproto-0.13.0/src/v4/mod.rs:286:21:
range end index 21 out of range for slice of length 16
```

Looking at the code, I think I see why. In the case where `chaddr`s length is greater than 16 and the `new_chaddr` is chunked to just 16 characters, the `hlen` is still being set to `chaddr`s length, which is possibly greater than 16 characters. I think that `hlen` should also be set to 16 in this case.