### PR TITLE
Add #[repr(transparent)] + const to numeric enums

### DIFF
--- a/src/v4/bulk_query.rs
+++ b/src/v4/bulk_query.rs
@@ -49,90 +49,73 @@ impl From<DataSourceFlags> for u8 {
     }
 }
 
+/// Bulk lease query state
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum QueryState {
-    Available,
-    Active,
-    Expired,
-    Release,
-    Abandoned,
-    Reset,
-    Remote,
-    Transitioning,
-    Unknown(u8),
+#[repr(transparent)]
+pub struct QueryState(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl QueryState {
+    /// Available
+    pub const Available: Self = Self(1);
+    /// Active
+    pub const Active: Self = Self(2);
+    /// Expired
+    pub const Expired: Self = Self(3);
+    /// Release
+    pub const Release: Self = Self(4);
+    /// Abandoned
+    pub const Abandoned: Self = Self(5);
+    /// Reset
+    pub const Reset: Self = Self(6);
+    /// Remote
+    pub const Remote: Self = Self(7);
+    /// Transitioning
+    pub const Transitioning: Self = Self(8);
 }
 
 impl From<u8> for QueryState {
     fn from(n: u8) -> Self {
-        use QueryState::*;
-        match n {
-            1 => Available,
-            2 => Active,
-            3 => Expired,
-            4 => Release,
-            5 => Abandoned,
-            6 => Reset,
-            7 => Remote,
-            8 => Transitioning,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<QueryState> for u8 {
     fn from(state: QueryState) -> Self {
-        use QueryState as Q;
-        match state {
-            Q::Available => 1,
-            Q::Active => 2,
-            Q::Expired => 3,
-            Q::Release => 4,
-            Q::Abandoned => 5,
-            Q::Reset => 6,
-            Q::Remote => 7,
-            Q::Transitioning => 8,
-            Q::Unknown(code) => code,
-        }
+        state.0
     }
 }
 
+/// Bulk lease query status code
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Code {
-    Success,
-    UnspecFail,
-    QueryTerminated,
-    MalformedQuery,
-    NotAllowed,
-    Unknown(u8),
+#[repr(transparent)]
+pub struct Code(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl Code {
+    /// Success
+    pub const Success: Self = Self(0);
+    /// UnspecFail
+    pub const UnspecFail: Self = Self(1);
+    /// QueryTerminated
+    pub const QueryTerminated: Self = Self(2);
+    /// MalformedQuery
+    pub const MalformedQuery: Self = Self(3);
+    /// NotAllowed
+    pub const NotAllowed: Self = Self(4);
 }
 
 impl From<u8> for Code {
     fn from(n: u8) -> Self {
-        use Code::*;
-        match n {
-            0 => Success,
-            1 => UnspecFail,
-            2 => QueryTerminated,
-            3 => MalformedQuery,
-            4 => NotAllowed,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<Code> for u8 {
     fn from(code: Code) -> Self {
-        use Code as C;
-        match code {
-            C::Success => 0,
-            C::UnspecFail => 1,
-            C::QueryTerminated => 2,
-            C::MalformedQuery => 3,
-            C::NotAllowed => 4,
-            C::Unknown(code) => code,
-        }
+        code.0
     }
 }
 

--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -10,134 +10,76 @@ use serde::{Deserialize, Serialize};
 /// Hardware type of message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
-pub enum HType {
+#[repr(transparent)]
+pub struct HType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl HType {
     /// 1 Ethernet
-    Eth,
+    pub const Eth: Self = Self(1);
     /// 2 Experimental Ethernet
-    ExperimentalEth,
+    pub const ExperimentalEth: Self = Self(2);
     /// 3 Amateur Radio AX25
-    AmRadioAX25,
+    pub const AmRadioAX25: Self = Self(3);
     /// 4 Proteon Token Ring
-    ProteonTokenRing,
+    pub const ProteonTokenRing: Self = Self(4);
     /// 5 Chaos
-    Chaos,
+    pub const Chaos: Self = Self(5);
     /// 6 IEEE.802
-    IEEE802,
+    pub const IEEE802: Self = Self(6);
     /// 7 ARCNET
-    ARCNET,
+    pub const ARCNET: Self = Self(7);
     /// 8 Hyperchannel
-    Hyperchannel,
+    pub const Hyperchannel: Self = Self(8);
     /// 9 LANSTAR
-    Lanstar,
+    pub const Lanstar: Self = Self(9);
     /// 10 Autonet Short Addr
-    AutonetShortAddr,
+    pub const AutonetShortAddr: Self = Self(10);
     /// 11 LocalTalk
-    LocalTalk,
+    pub const LocalTalk: Self = Self(11);
     /// 12 LocalNet
-    LocalNet,
+    pub const LocalNet: Self = Self(12);
     /// 13 Ultralink
-    Ultralink,
+    pub const Ultralink: Self = Self(13);
     /// 14 SMDS
-    SMDS,
+    pub const SMDS: Self = Self(14);
     /// 15 FrameRelay
-    FrameRelay,
+    pub const FrameRelay: Self = Self(15);
     /// 17 HDLC
-    HDLC,
+    pub const HDLC: Self = Self(17);
     /// 18 FibreChannel
-    FibreChannel,
+    pub const FibreChannel: Self = Self(18);
     /// 20 SerialLine
-    SerialLine,
+    pub const SerialLine: Self = Self(20);
     /// 22 Mil STD
-    MilStd188220,
+    pub const MilStd188220: Self = Self(22);
     /// 23 Metricom
-    Metricom,
+    pub const Metricom: Self = Self(23);
     /// 25 MAPOS
-    MAPOS,
+    pub const MAPOS: Self = Self(25);
     /// 26 Twinaxial
-    Twinaxial,
+    pub const Twinaxial: Self = Self(26);
     /// 30 ARPSec
-    ARPSec,
+    pub const ARPSec: Self = Self(30);
     /// 31 IPsec tunnel
-    IPsecTunnel,
+    pub const IPsecTunnel: Self = Self(31);
     /// 32 Infiniband
-    Infiniband,
-    /// 34 WeigandInt
-    WiegandInt,
+    pub const Infiniband: Self = Self(32);
+    /// 34 WiegandInt
+    pub const WiegandInt: Self = Self(34);
     /// 35 PureIP
-    PureIP,
-    /// Unknown or not yet implemented htype
-    Unknown(u8),
+    pub const PureIP: Self = Self(35);
 }
 
 impl From<u8> for HType {
     fn from(n: u8) -> Self {
-        use HType::*;
-        match n {
-            1 => Eth,
-            2 => ExperimentalEth,
-            3 => AmRadioAX25,
-            4 => ProteonTokenRing,
-            5 => Chaos,
-            6 => IEEE802,
-            7 => ARCNET,
-            8 => Hyperchannel,
-            9 => Lanstar,
-            10 => AutonetShortAddr,
-            11 => LocalTalk,
-            12 => LocalNet,
-            13 => Ultralink,
-            14 => SMDS,
-            15 => FrameRelay,
-            17 => HDLC,
-            18 => FibreChannel,
-            20 => SerialLine,
-            22 => MilStd188220,
-            23 => Metricom,
-            25 => MAPOS,
-            26 => Twinaxial,
-            30 => ARPSec,
-            31 => IPsecTunnel,
-            32 => Infiniband,
-            34 => WiegandInt,
-            35 => PureIP,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<HType> for u8 {
     fn from(n: HType) -> Self {
-        use HType as H;
-        match n {
-            H::Eth => 1,
-            H::ExperimentalEth => 2,
-            H::AmRadioAX25 => 3,
-            H::ProteonTokenRing => 4,
-            H::Chaos => 5,
-            H::IEEE802 => 6,
-            H::ARCNET => 7,
-            H::Hyperchannel => 8,
-            H::Lanstar => 9,
-            H::AutonetShortAddr => 10,
-            H::LocalTalk => 11,
-            H::LocalNet => 12,
-            H::Ultralink => 13,
-            H::SMDS => 14,
-            H::FrameRelay => 15,
-            H::HDLC => 17,
-            H::FibreChannel => 18,
-            H::SerialLine => 20,
-            H::MilStd188220 => 22,
-            H::Metricom => 23,
-            H::MAPOS => 25,
-            H::Twinaxial => 26,
-            H::ARPSec => 30,
-            H::IPsecTunnel => 31,
-            H::Infiniband => 32,
-            H::WiegandInt => 34,
-            H::PureIP => 35,
-            H::Unknown(n) => n,
-        }
+        n.0
     }
 }
 

--- a/src/v4/opcode.rs
+++ b/src/v4/opcode.rs
@@ -9,13 +9,15 @@ use serde::{Deserialize, Serialize};
 /// Opcode of Message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Opcode {
+#[repr(transparent)]
+pub struct Opcode(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl Opcode {
     /// BootRequest - <https://datatracker.ietf.org/doc/html/rfc1534#section-2>
-    BootRequest,
+    pub const BootRequest: Self = Self(1);
     /// BootReply - <https://datatracker.ietf.org/doc/html/rfc1534#section-2>
-    BootReply,
-    /// Unknown or not yet implemented
-    Unknown(u8),
+    pub const BootReply: Self = Self(2);
 }
 
 impl Decodable for Opcode {
@@ -32,19 +34,12 @@ impl Encodable for Opcode {
 
 impl From<u8> for Opcode {
     fn from(opcode: u8) -> Self {
-        match opcode {
-            1 => Opcode::BootRequest,
-            2 => Opcode::BootReply,
-            _ => Opcode::Unknown(opcode),
-        }
+        Self(opcode)
     }
 }
+
 impl From<Opcode> for u8 {
     fn from(opcode: Opcode) -> Self {
-        match opcode {
-            Opcode::BootRequest => 1,
-            Opcode::BootReply => 2,
-            Opcode::Unknown(opcode) => opcode,
-        }
+        opcode.0
     }
 }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -518,42 +518,30 @@ impl From<Architecture> for u16 {
 /// NetBIOS allows several different node types
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NodeType {
+#[repr(transparent)]
+pub struct NodeType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl NodeType {
     /// Broadcast
-    B,
+    pub const B: Self = Self(1);
     /// Peer-to-peer
-    P,
+    pub const P: Self = Self(2);
     /// Mixed (B & P)
-    M,
+    pub const M: Self = Self(4);
     /// Hybrid (P & B)
-    H,
-    /// Unknown
-    Unknown(u8),
+    pub const H: Self = Self(8);
 }
 
 impl From<u8> for NodeType {
     fn from(n: u8) -> Self {
-        use NodeType::*;
-        match n {
-            1 => B,
-            2 => P,
-            4 => M,
-            8 => H,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<NodeType> for u8 {
     fn from(n: NodeType) -> Self {
-        use NodeType as N;
-        match n {
-            N::B => 1,
-            N::P => 2,
-            N::M => 4,
-            N::H => 8,
-            N::Unknown(n) => n,
-        }
+        n.0
     }
 }
 
@@ -1257,95 +1245,58 @@ impl Encodable for UnknownOption {
 /// <https://datatracker.ietf.org/doc/html/rfc2131#section-3.1>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MessageType {
+#[repr(transparent)]
+pub struct MessageType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl MessageType {
     /// DHCPDiscover
-    Discover,
+    pub const Discover: Self = Self(1);
     /// DHCPOffer
-    Offer,
+    pub const Offer: Self = Self(2);
     /// DHCPRequest
-    Request,
+    pub const Request: Self = Self(3);
     /// DHCPDecline
-    Decline,
+    pub const Decline: Self = Self(4);
     /// DHCPAck
-    Ack,
+    pub const Ack: Self = Self(5);
     /// DHCPNak
-    Nak,
+    pub const Nak: Self = Self(6);
     /// DHCPRelease
-    Release,
+    pub const Release: Self = Self(7);
     /// DHCPInform
-    Inform,
+    pub const Inform: Self = Self(8);
     /// DHCPForceRenew - <https://www.rfc-editor.org/rfc/rfc3203.html>
-    ForceRenew,
+    pub const ForceRenew: Self = Self(9);
     /// DHCPLeaseQuery - <https://www.rfc-editor.org/rfc/rfc4388#section-6.1>
-    LeaseQuery,
+    pub const LeaseQuery: Self = Self(10);
     /// DHCPLeaseUnassigned
-    LeaseUnassigned,
+    pub const LeaseUnassigned: Self = Self(11);
     /// DHCPLeaseUnknown
-    LeaseUnknown,
+    pub const LeaseUnknown: Self = Self(12);
     /// DHCPLeaseActive
-    LeaseActive,
+    pub const LeaseActive: Self = Self(13);
     /// DHCPBulkLeaseQuery - <https://www.rfc-editor.org/rfc/rfc6926.html>
-    BulkLeaseQuery,
+    pub const BulkLeaseQuery: Self = Self(14);
     /// DHCPLeaseQueryDone
-    LeaseQueryDone,
+    pub const LeaseQueryDone: Self = Self(15);
     /// DHCPActiveLeaseQuery - <https://www.rfc-editor.org/rfc/rfc7724.html>
-    ActiveLeaseQuery,
+    pub const ActiveLeaseQuery: Self = Self(16);
     /// DHCPLeaseQueryStatus
-    LeaseQueryStatus,
+    pub const LeaseQueryStatus: Self = Self(17);
     /// DHCPTLS
-    Tls,
-    /// an unknown message type
-    Unknown(u8),
+    pub const Tls: Self = Self(18);
 }
 
 impl From<u8> for MessageType {
     fn from(n: u8) -> Self {
-        match n {
-            1 => MessageType::Discover,
-            2 => MessageType::Offer,
-            3 => MessageType::Request,
-            4 => MessageType::Decline,
-            5 => MessageType::Ack,
-            6 => MessageType::Nak,
-            7 => MessageType::Release,
-            8 => MessageType::Inform,
-            9 => MessageType::ForceRenew,
-            10 => MessageType::LeaseQuery,
-            11 => MessageType::LeaseUnassigned,
-            12 => MessageType::LeaseUnknown,
-            13 => MessageType::LeaseActive,
-            14 => MessageType::BulkLeaseQuery,
-            15 => MessageType::LeaseQueryDone,
-            16 => MessageType::ActiveLeaseQuery,
-            17 => MessageType::LeaseQueryStatus,
-            18 => MessageType::Tls,
-            n => MessageType::Unknown(n),
-        }
+        Self(n)
     }
 }
+
 impl From<MessageType> for u8 {
     fn from(m: MessageType) -> Self {
-        match m {
-            MessageType::Discover => 1,
-            MessageType::Offer => 2,
-            MessageType::Request => 3,
-            MessageType::Decline => 4,
-            MessageType::Ack => 5,
-            MessageType::Nak => 6,
-            MessageType::Release => 7,
-            MessageType::Inform => 8,
-            MessageType::ForceRenew => 9,
-            MessageType::LeaseQuery => 10,
-            MessageType::LeaseUnassigned => 11,
-            MessageType::LeaseUnknown => 12,
-            MessageType::LeaseActive => 13,
-            MessageType::BulkLeaseQuery => 14,
-            MessageType::LeaseQueryDone => 15,
-            MessageType::ActiveLeaseQuery => 16,
-            MessageType::LeaseQueryStatus => 17,
-            MessageType::Tls => 18,
-            MessageType::Unknown(n) => n,
-        }
+        m.0
     }
 }
 

--- a/src/v6/htype.rs
+++ b/src/v6/htype.rs
@@ -11,177 +11,98 @@ use serde::{Deserialize, Serialize};
 /// Hardware type of message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
-pub enum HType {
+#[repr(transparent)]
+pub struct HType(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl HType {
     /// 1 Ethernet
-    Eth,
+    pub const Eth: Self = Self(1);
     /// 2 Experimental Ethernet
-    ExperimentalEth,
+    pub const ExperimentalEth: Self = Self(2);
     /// 3 Amateur Radio AX25
-    AmRadioAX25,
+    pub const AmRadioAX25: Self = Self(3);
     /// 4 Proteon Token Ring
-    ProteonTokenRing,
+    pub const ProteonTokenRing: Self = Self(4);
     /// 5 Chaos
-    Chaos,
+    pub const Chaos: Self = Self(5);
     /// 6 IEEE.802
-    IEEE802,
+    pub const IEEE802: Self = Self(6);
     /// 7 ARCNET
-    ARCNET,
+    pub const ARCNET: Self = Self(7);
     /// 8 Hyperchannel
-    Hyperchannel,
+    pub const Hyperchannel: Self = Self(8);
     /// 9 LANSTAR
-    Lanstar,
+    pub const Lanstar: Self = Self(9);
     /// 10 Autonet Short Addr
-    AutonetShortAddr,
+    pub const AutonetShortAddr: Self = Self(10);
     /// 11 LocalTalk
-    LocalTalk,
+    pub const LocalTalk: Self = Self(11);
     /// 12 LocalNet
-    LocalNet,
+    pub const LocalNet: Self = Self(12);
     /// 13 Ultralink
-    Ultralink,
+    pub const Ultralink: Self = Self(13);
     /// 14 SMDS
-    SMDS,
+    pub const SMDS: Self = Self(14);
     /// 15 FrameRelay
-    FrameRelay,
+    pub const FrameRelay: Self = Self(15);
     /// 17 HDLC
-    HDLC,
+    pub const HDLC: Self = Self(17);
     /// 18 FibreChannel
-    FibreChannel,
+    pub const FibreChannel: Self = Self(18);
     /// 20 SerialLine
-    SerialLine,
+    pub const SerialLine: Self = Self(20);
     /// 22 Mil STD
-    MilStd188220,
+    pub const MilStd188220: Self = Self(22);
     /// 23 Metricom
-    Metricom,
+    pub const Metricom: Self = Self(23);
     /// 24 IEEE1394.1995
-    IEEE13941995,
+    pub const IEEE13941995: Self = Self(24);
     /// 25 MAPOS
-    MAPOS,
+    pub const MAPOS: Self = Self(25);
     /// 26 Twinaxial
-    Twinaxial,
+    pub const Twinaxial: Self = Self(26);
     /// 27 EUI64
-    EUI64,
+    pub const EUI64: Self = Self(27);
     /// 28 HIPARP
-    HIPARP,
+    pub const HIPARP: Self = Self(28);
     /// 29 IP and ARP over ISO 7816-3
-    IPandARPoverISO78163,
+    pub const IPandARPoverISO78163: Self = Self(29);
     /// 30 ARPSec
-    ARPSec,
+    pub const ARPSec: Self = Self(30);
     /// 31 IPsec tunnel
-    IPsecTunnel,
+    pub const IPsecTunnel: Self = Self(31);
     /// 32 Infiniband
-    Infiniband,
+    pub const Infiniband: Self = Self(32);
     /// 33 TIA-102 Project 25 Common Air Interface (CAI)
-    CAI,
-    /// 34 WeigandInt
-    WiegandInt,
+    pub const CAI: Self = Self(33);
+    /// 34 WiegandInt
+    pub const WiegandInt: Self = Self(34);
     /// 35 PureIP
-    PureIP,
+    pub const PureIP: Self = Self(35);
     /// 36 HW_EXP1
-    HWExp1,
+    pub const HWExp1: Self = Self(36);
     /// 37 HFI
-    HFI,
-    /// 38 Unified BUS(UB),
-    UB,
+    pub const HFI: Self = Self(37);
+    /// 38 Unified BUS(UB)
+    pub const UB: Self = Self(38);
     /// 256 HW_EXP2
-    HWExp2,
+    pub const HWExp2: Self = Self(256);
     /// 257 AEthernet
-    AEthernet,
+    pub const AEthernet: Self = Self(257);
     /// 65535 Reserved
-    Reserved,
-    /// Unknown or not yet implemented htype
-    Unknown(u16),
+    pub const Reserved: Self = Self(65535);
 }
+
 impl From<u16> for HType {
     fn from(n: u16) -> Self {
-        use HType::*;
-        match n {
-            1 => Eth,
-            2 => ExperimentalEth,
-            3 => AmRadioAX25,
-            4 => ProteonTokenRing,
-            5 => Chaos,
-            6 => IEEE802,
-            7 => ARCNET,
-            8 => Hyperchannel,
-            9 => Lanstar,
-            10 => AutonetShortAddr,
-            11 => LocalTalk,
-            12 => LocalNet,
-            13 => Ultralink,
-            14 => SMDS,
-            15 => FrameRelay,
-            17 => HDLC,
-            18 => FibreChannel,
-            20 => SerialLine,
-            22 => MilStd188220,
-            23 => Metricom,
-            24 => IEEE13941995,
-            25 => MAPOS,
-            26 => Twinaxial,
-            27 => EUI64,
-            28 => HIPARP,
-            29 => IPandARPoverISO78163,
-            30 => ARPSec,
-            31 => IPsecTunnel,
-            32 => Infiniband,
-            33 => CAI,
-            34 => WiegandInt,
-            35 => PureIP,
-            36 => HWExp1,
-            37 => HFI,
-            38 => UB,
-            256 => HWExp2,
-            257 => AEthernet,
-            65535 => Reserved,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<HType> for u16 {
     fn from(n: HType) -> Self {
-        use HType as H;
-        match n {
-            H::Eth => 1,
-            H::ExperimentalEth => 2,
-            H::AmRadioAX25 => 3,
-            H::ProteonTokenRing => 4,
-            H::Chaos => 5,
-            H::IEEE802 => 6,
-            H::ARCNET => 7,
-            H::Hyperchannel => 8,
-            H::Lanstar => 9,
-            H::AutonetShortAddr => 10,
-            H::LocalTalk => 11,
-            H::LocalNet => 12,
-            H::Ultralink => 13,
-            H::SMDS => 14,
-            H::FrameRelay => 15,
-            H::HDLC => 17,
-            H::FibreChannel => 18,
-            H::SerialLine => 20,
-            H::MilStd188220 => 22,
-            H::Metricom => 23,
-            H::IEEE13941995 => 24,
-            H::MAPOS => 25,
-            H::Twinaxial => 26,
-            H::EUI64 => 27,
-            H::HIPARP => 28,
-            H::IPandARPoverISO78163 => 29,
-            H::ARPSec => 30,
-            H::IPsecTunnel => 31,
-            H::Infiniband => 32,
-            H::CAI => 33,
-            H::WiegandInt => 34,
-            H::PureIP => 35,
-            H::HWExp1 => 36,
-            H::HFI => 37,
-            H::UB => 38,
-            H::HWExp2 => 256,
-            H::AEthernet => 257,
-            H::Reserved => 65535,
-            H::Unknown(n) => n,
-        }
+        n.0
     }
 }
 

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -220,125 +220,69 @@ impl Message {
 /// <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MessageType {
+#[repr(transparent)]
+pub struct MessageType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl MessageType {
     // RFC 3315
     /// client solicit - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Solicit,
+    pub const Solicit: Self = Self(1);
     /// server advertise - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Advertise,
+    pub const Advertise: Self = Self(2);
     /// request - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Request,
+    pub const Request: Self = Self(3);
     /// confirm - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Confirm,
+    pub const Confirm: Self = Self(4);
     /// renew - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Renew,
+    pub const Renew: Self = Self(5);
     /// rebind - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Rebind,
+    pub const Rebind: Self = Self(6);
     /// reply - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Reply,
+    pub const Reply: Self = Self(7);
     /// release message type - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Release,
+    pub const Release: Self = Self(8);
     /// decline - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Decline,
+    pub const Decline: Self = Self(9);
     /// reconfigure - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Reconfigure,
+    pub const Reconfigure: Self = Self(10);
     /// information request - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    InformationRequest,
+    pub const InformationRequest: Self = Self(11);
     /// relay forward - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    RelayForw,
+    pub const RelayForw: Self = Self(12);
     /// relay reply - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    RelayRepl,
+    pub const RelayRepl: Self = Self(13);
     // RFC 5007
     /// lease query - <https://datatracker.ietf.org/doc/html/rfc5007#section-4.2.1>
-    LeaseQuery,
+    pub const LeaseQuery: Self = Self(14);
     /// lease query reply - <https://datatracker.ietf.org/doc/html/rfc5007#section-4.2.2>
-    LeaseQueryReply,
+    pub const LeaseQueryReply: Self = Self(15);
     // RFC 5460
     /// lease query done - <https://datatracker.ietf.org/doc/html/rfc5460#section-5.2.2>
-    LeaseQueryDone,
+    pub const LeaseQueryDone: Self = Self(16);
     /// lease query data - <https://datatracker.ietf.org/doc/html/rfc5460#section-5.2.1>
-    LeaseQueryData,
+    pub const LeaseQueryData: Self = Self(17);
     // RFC 6977
     /// reconfigure request - <https://datatracker.ietf.org/doc/html/rfc6977#section-6.2.1>
-    ReconfigureRequest,
+    pub const ReconfigureRequest: Self = Self(18);
     /// reconfigure reply - <https://datatracker.ietf.org/doc/html/rfc6977#section-6.2.2>
-    ReconfigureReply,
+    pub const ReconfigureReply: Self = Self(19);
     // RFC 7341
     /// dhcpv4 query - <https://datatracker.ietf.org/doc/html/rfc7341#section-6.2>
-    DHCPv4Query,
+    pub const DHCPv4Query: Self = Self(20);
     /// dhcpv4 response - <https://datatracker.ietf.org/doc/html/rfc7341#section-6.2>
-    DHCPv4Response,
-    /// unknown/unimplemented message type
-    Unknown(u8),
+    pub const DHCPv4Response: Self = Self(21);
 }
 
 impl From<u8> for MessageType {
     fn from(n: u8) -> Self {
-        use MessageType::*;
-        match n {
-            // RFC 3315
-            1 => Solicit,
-            2 => Advertise,
-            3 => Request,
-            4 => Confirm,
-            5 => Renew,
-            6 => Rebind,
-            7 => Reply,
-            8 => Release,
-            9 => Decline,
-            10 => Reconfigure,
-            11 => InformationRequest,
-            12 => RelayForw,
-            13 => RelayRepl,
-            // RFC 5007
-            14 => LeaseQuery,
-            15 => LeaseQueryReply,
-            // RFC 5460
-            16 => LeaseQueryDone,
-            17 => LeaseQueryData,
-            // RFC 6977
-            18 => ReconfigureRequest,
-            19 => ReconfigureReply,
-            // RFC 7341
-            20 => DHCPv4Query,
-            21 => DHCPv4Response,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<MessageType> for u8 {
     fn from(m: MessageType) -> Self {
-        use MessageType as M;
-        match m {
-            // RFC 3315
-            M::Solicit => 1,
-            M::Advertise => 2,
-            M::Request => 3,
-            M::Confirm => 4,
-            M::Renew => 5,
-            M::Rebind => 6,
-            M::Reply => 7,
-            M::Release => 8,
-            M::Decline => 9,
-            M::Reconfigure => 10,
-            M::InformationRequest => 11,
-            M::RelayForw => 12,
-            M::RelayRepl => 13,
-            // RFC 5007
-            M::LeaseQuery => 14,
-            M::LeaseQueryReply => 15,
-            // RFC 5460
-            M::LeaseQueryDone => 16,
-            M::LeaseQueryData => 17,
-            // RFC 6977
-            M::ReconfigureRequest => 18,
-            M::ReconfigureReply => 19,
-            // RFC 7341
-            M::DHCPv4Query => 20,
-            M::DHCPv4Response => 21,
-            M::Unknown(n) => n,
-        }
+        m.0
     }
 }
 

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -243,94 +243,68 @@ pub struct StatusCode {
 /// Status code for Server Unicast
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Status {
-    Success,
-    UnspecFail,
-    NoAddrsAvail,
-    NoBinding,
-    NotOnLink,
-    UseMulticast,
-    NoPrefixAvail,
-    UnknownQueryType,
-    MalformedQuery,
-    NotConfigured,
-    NotAllowed,
-    QueryTerminated,
-    DataMissing,
-    CatchUpComplete,
-    NotSupported,
-    TLSConnectionRefused,
-    AddressInUse,
-    ConfigurationConflict,
-    MissingBindingInformation,
-    OutdatedBindingInformation,
-    ServerShuttingDown,
-    DNSUpdateNotSupported,
-    ExcessiveTimeSkew,
-    /// unknown/unimplemented message type
-    Unknown(u16),
+#[repr(transparent)]
+pub struct Status(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl Status {
+    /// Success
+    pub const Success: Self = Self(0);
+    /// UnspecFail
+    pub const UnspecFail: Self = Self(1);
+    /// NoAddrsAvail
+    pub const NoAddrsAvail: Self = Self(2);
+    /// NoBinding
+    pub const NoBinding: Self = Self(3);
+    /// NotOnLink
+    pub const NotOnLink: Self = Self(4);
+    /// UseMulticast
+    pub const UseMulticast: Self = Self(5);
+    /// NoPrefixAvail
+    pub const NoPrefixAvail: Self = Self(6);
+    /// UnknownQueryType
+    pub const UnknownQueryType: Self = Self(7);
+    /// MalformedQuery
+    pub const MalformedQuery: Self = Self(8);
+    /// NotConfigured
+    pub const NotConfigured: Self = Self(9);
+    /// NotAllowed
+    pub const NotAllowed: Self = Self(10);
+    /// QueryTerminated
+    pub const QueryTerminated: Self = Self(11);
+    /// DataMissing
+    pub const DataMissing: Self = Self(12);
+    /// CatchUpComplete
+    pub const CatchUpComplete: Self = Self(13);
+    /// NotSupported
+    pub const NotSupported: Self = Self(14);
+    /// TLSConnectionRefused
+    pub const TLSConnectionRefused: Self = Self(15);
+    /// AddressInUse
+    pub const AddressInUse: Self = Self(16);
+    /// ConfigurationConflict
+    pub const ConfigurationConflict: Self = Self(17);
+    /// MissingBindingInformation
+    pub const MissingBindingInformation: Self = Self(18);
+    /// OutdatedBindingInformation
+    pub const OutdatedBindingInformation: Self = Self(19);
+    /// ServerShuttingDown
+    pub const ServerShuttingDown: Self = Self(20);
+    /// DNSUpdateNotSupported
+    pub const DNSUpdateNotSupported: Self = Self(21);
+    /// ExcessiveTimeSkew
+    pub const ExcessiveTimeSkew: Self = Self(22);
 }
 
 impl From<u16> for Status {
     fn from(n: u16) -> Self {
-        use Status::*;
-        match n {
-            0 => Success,
-            1 => UnspecFail,
-            2 => NoAddrsAvail,
-            3 => NoBinding,
-            4 => NotOnLink,
-            5 => UseMulticast,
-            6 => NoPrefixAvail,
-            7 => UnknownQueryType,
-            8 => MalformedQuery,
-            9 => NotConfigured,
-            10 => NotAllowed,
-            11 => QueryTerminated,
-            12 => DataMissing,
-            13 => CatchUpComplete,
-            14 => NotSupported,
-            15 => TLSConnectionRefused,
-            16 => AddressInUse,
-            17 => ConfigurationConflict,
-            18 => MissingBindingInformation,
-            19 => OutdatedBindingInformation,
-            20 => ServerShuttingDown,
-            21 => DNSUpdateNotSupported,
-            22 => ExcessiveTimeSkew,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
+
 impl From<Status> for u16 {
     fn from(n: Status) -> Self {
-        use Status as S;
-        match n {
-            S::Success => 0,
-            S::UnspecFail => 1,
-            S::NoAddrsAvail => 2,
-            S::NoBinding => 3,
-            S::NotOnLink => 4,
-            S::UseMulticast => 5,
-            S::NoPrefixAvail => 6,
-            S::UnknownQueryType => 7,
-            S::MalformedQuery => 8,
-            S::NotConfigured => 9,
-            S::NotAllowed => 10,
-            S::QueryTerminated => 11,
-            S::DataMissing => 12,
-            S::CatchUpComplete => 13,
-            S::NotSupported => 14,
-            S::TLSConnectionRefused => 15,
-            S::AddressInUse => 16,
-            S::ConfigurationConflict => 17,
-            S::MissingBindingInformation => 18,
-            S::OutdatedBindingInformation => 19,
-            S::ServerShuttingDown => 20,
-            S::DNSUpdateNotSupported => 21,
-            S::ExcessiveTimeSkew => 22,
-            S::Unknown(n) => n,
-        }
+        n.0
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #100. Converts 9 numeric enum types from the traditional `enum E { Variant, ..., Unknown(uN) }` pattern to `#[repr(transparent)] pub struct E(pub uN)` newtype structs with `pub const` values, following the exact pattern introduced by #99 (`Architecture` conversion, merged 2026-05-09).

## Converted types

- `v4::HType`, `v4::Opcode`, `v4::NodeType`, `v4::MessageType`, `v4::bulk_query::QueryState`, `v4::bulk_query::Code`
- `v6::HType`, `v6::MessageType`, `v6::Status`

## Intentionally excluded

`v6::OptionCode`, `v6::OROCode`, and `v4::relay::RelayCode` are used in hundreds of pattern-match arms across decode logic (369 call sites vs 30 for the converted types). They would require a separate, larger refactor and are left for a follow-up PR.

## Verification

`cargo build --all-features`, `cargo test --all-features` (55 unit + 18 doc tests), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all pass locally on Rust 1.90.0.

---

Prepared with AI assistance (Claude Sonnet 4.6 via Claude Code).