### PR TITLE
Switch numbered enum types to repr(transparent)

### DIFF
--- a/src/v4/bulk_query.rs
+++ b/src/v4/bulk_query.rs
@@ -51,88 +51,56 @@ impl From<DataSourceFlags> for u8 {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum QueryState {
-    Available,
-    Active,
-    Expired,
-    Release,
-    Abandoned,
-    Reset,
-    Remote,
-    Transitioning,
-    Unknown(u8),
+#[repr(transparent)]
+pub struct QueryState(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl QueryState {
+    pub const Available: Self = Self(1);
+    pub const Active: Self = Self(2);
+    pub const Expired: Self = Self(3);
+    pub const Release: Self = Self(4);
+    pub const Abandoned: Self = Self(5);
+    pub const Reset: Self = Self(6);
+    pub const Remote: Self = Self(7);
+    pub const Transitioning: Self = Self(8);
 }
 
 impl From<u8> for QueryState {
     fn from(n: u8) -> Self {
-        use QueryState::*;
-        match n {
-            1 => Available,
-            2 => Active,
-            3 => Expired,
-            4 => Release,
-            5 => Abandoned,
-            6 => Reset,
-            7 => Remote,
-            8 => Transitioning,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<QueryState> for u8 {
     fn from(state: QueryState) -> Self {
-        use QueryState as Q;
-        match state {
-            Q::Available => 1,
-            Q::Active => 2,
-            Q::Expired => 3,
-            Q::Release => 4,
-            Q::Abandoned => 5,
-            Q::Reset => 6,
-            Q::Remote => 7,
-            Q::Transitioning => 8,
-            Q::Unknown(code) => code,
-        }
+        state.0
     }
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Code {
-    Success,
-    UnspecFail,
-    QueryTerminated,
-    MalformedQuery,
-    NotAllowed,
-    Unknown(u8),
+#[repr(transparent)]
+pub struct Code(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl Code {
+    pub const Success: Self = Self(0);
+    pub const UnspecFail: Self = Self(1);
+    pub const QueryTerminated: Self = Self(2);
+    pub const MalformedQuery: Self = Self(3);
+    pub const NotAllowed: Self = Self(4);
 }
 
 impl From<u8> for Code {
     fn from(n: u8) -> Self {
-        use Code::*;
-        match n {
-            0 => Success,
-            1 => UnspecFail,
-            2 => QueryTerminated,
-            3 => MalformedQuery,
-            4 => NotAllowed,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<Code> for u8 {
     fn from(code: Code) -> Self {
-        use Code as C;
-        match code {
-            C::Success => 0,
-            C::UnspecFail => 1,
-            C::QueryTerminated => 2,
-            C::MalformedQuery => 3,
-            C::NotAllowed => 4,
-            C::Unknown(code) => code,
-        }
+        code.0
     }
 }
 

--- a/src/v4/htype.rs
+++ b/src/v4/htype.rs
@@ -10,134 +10,76 @@ use serde::{Deserialize, Serialize};
 /// Hardware type of message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
-pub enum HType {
+#[repr(transparent)]
+pub struct HType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl HType {
     /// 1 Ethernet
-    Eth,
+    pub const Eth: Self = Self(1);
     /// 2 Experimental Ethernet
-    ExperimentalEth,
+    pub const ExperimentalEth: Self = Self(2);
     /// 3 Amateur Radio AX25
-    AmRadioAX25,
+    pub const AmRadioAX25: Self = Self(3);
     /// 4 Proteon Token Ring
-    ProteonTokenRing,
+    pub const ProteonTokenRing: Self = Self(4);
     /// 5 Chaos
-    Chaos,
+    pub const Chaos: Self = Self(5);
     /// 6 IEEE.802
-    IEEE802,
+    pub const IEEE802: Self = Self(6);
     /// 7 ARCNET
-    ARCNET,
+    pub const ARCNET: Self = Self(7);
     /// 8 Hyperchannel
-    Hyperchannel,
+    pub const Hyperchannel: Self = Self(8);
     /// 9 LANSTAR
-    Lanstar,
+    pub const Lanstar: Self = Self(9);
     /// 10 Autonet Short Addr
-    AutonetShortAddr,
+    pub const AutonetShortAddr: Self = Self(10);
     /// 11 LocalTalk
-    LocalTalk,
+    pub const LocalTalk: Self = Self(11);
     /// 12 LocalNet
-    LocalNet,
+    pub const LocalNet: Self = Self(12);
     /// 13 Ultralink
-    Ultralink,
+    pub const Ultralink: Self = Self(13);
     /// 14 SMDS
-    SMDS,
+    pub const SMDS: Self = Self(14);
     /// 15 FrameRelay
-    FrameRelay,
+    pub const FrameRelay: Self = Self(15);
     /// 17 HDLC
-    HDLC,
+    pub const HDLC: Self = Self(17);
     /// 18 FibreChannel
-    FibreChannel,
+    pub const FibreChannel: Self = Self(18);
     /// 20 SerialLine
-    SerialLine,
+    pub const SerialLine: Self = Self(20);
     /// 22 Mil STD
-    MilStd188220,
+    pub const MilStd188220: Self = Self(22);
     /// 23 Metricom
-    Metricom,
+    pub const Metricom: Self = Self(23);
     /// 25 MAPOS
-    MAPOS,
+    pub const MAPOS: Self = Self(25);
     /// 26 Twinaxial
-    Twinaxial,
+    pub const Twinaxial: Self = Self(26);
     /// 30 ARPSec
-    ARPSec,
+    pub const ARPSec: Self = Self(30);
     /// 31 IPsec tunnel
-    IPsecTunnel,
+    pub const IPsecTunnel: Self = Self(31);
     /// 32 Infiniband
-    Infiniband,
+    pub const Infiniband: Self = Self(32);
     /// 34 WeigandInt
-    WiegandInt,
+    pub const WiegandInt: Self = Self(34);
     /// 35 PureIP
-    PureIP,
-    /// Unknown or not yet implemented htype
-    Unknown(u8),
+    pub const PureIP: Self = Self(35);
 }
 
 impl From<u8> for HType {
     fn from(n: u8) -> Self {
-        use HType::*;
-        match n {
-            1 => Eth,
-            2 => ExperimentalEth,
-            3 => AmRadioAX25,
-            4 => ProteonTokenRing,
-            5 => Chaos,
-            6 => IEEE802,
-            7 => ARCNET,
-            8 => Hyperchannel,
-            9 => Lanstar,
-            10 => AutonetShortAddr,
-            11 => LocalTalk,
-            12 => LocalNet,
-            13 => Ultralink,
-            14 => SMDS,
-            15 => FrameRelay,
-            17 => HDLC,
-            18 => FibreChannel,
-            20 => SerialLine,
-            22 => MilStd188220,
-            23 => Metricom,
-            25 => MAPOS,
-            26 => Twinaxial,
-            30 => ARPSec,
-            31 => IPsecTunnel,
-            32 => Infiniband,
-            34 => WiegandInt,
-            35 => PureIP,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<HType> for u8 {
     fn from(n: HType) -> Self {
-        use HType as H;
-        match n {
-            H::Eth => 1,
-            H::ExperimentalEth => 2,
-            H::AmRadioAX25 => 3,
-            H::ProteonTokenRing => 4,
-            H::Chaos => 5,
-            H::IEEE802 => 6,
-            H::ARCNET => 7,
-            H::Hyperchannel => 8,
-            H::Lanstar => 9,
-            H::AutonetShortAddr => 10,
-            H::LocalTalk => 11,
-            H::LocalNet => 12,
-            H::Ultralink => 13,
-            H::SMDS => 14,
-            H::FrameRelay => 15,
-            H::HDLC => 17,
-            H::FibreChannel => 18,
-            H::SerialLine => 20,
-            H::MilStd188220 => 22,
-            H::Metricom => 23,
-            H::MAPOS => 25,
-            H::Twinaxial => 26,
-            H::ARPSec => 30,
-            H::IPsecTunnel => 31,
-            H::Infiniband => 32,
-            H::WiegandInt => 34,
-            H::PureIP => 35,
-            H::Unknown(n) => n,
-        }
+        n.0
     }
 }
 

--- a/src/v4/opcode.rs
+++ b/src/v4/opcode.rs
@@ -8,14 +8,16 @@ use serde::{Deserialize, Serialize};
 
 /// Opcode of Message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Opcode {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct Opcode(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl Opcode {
     /// BootRequest - <https://datatracker.ietf.org/doc/html/rfc1534#section-2>
-    BootRequest,
+    pub const BootRequest: Self = Self(1);
     /// BootReply - <https://datatracker.ietf.org/doc/html/rfc1534#section-2>
-    BootReply,
-    /// Unknown or not yet implemented
-    Unknown(u8),
+    pub const BootReply: Self = Self(2);
 }
 
 impl Decodable for Opcode {
@@ -32,19 +34,12 @@ impl Encodable for Opcode {
 
 impl From<u8> for Opcode {
     fn from(opcode: u8) -> Self {
-        match opcode {
-            1 => Opcode::BootRequest,
-            2 => Opcode::BootReply,
-            _ => Opcode::Unknown(opcode),
-        }
+        Self(opcode)
     }
 }
+
 impl From<Opcode> for u8 {
     fn from(opcode: Opcode) -> Self {
-        match opcode {
-            Opcode::BootRequest => 1,
-            Opcode::BootReply => 2,
-            Opcode::Unknown(opcode) => opcode,
-        }
+        opcode.0
     }
 }

--- a/src/v4/options.rs
+++ b/src/v4/options.rs
@@ -520,68 +520,56 @@ impl From<Architecture> for u16 {
 /// NetBIOS allows several different node types
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NodeType {
+#[repr(transparent)]
+pub struct NodeType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl NodeType {
     /// Broadcast
-    B,
+    pub const B: Self = Self(1);
     /// Peer-to-peer
-    P,
+    pub const P: Self = Self(2);
     /// Mixed (B & P)
-    M,
+    pub const M: Self = Self(4);
     /// Hybrid (P & B)
-    H,
-    /// Unknown
-    Unknown(u8),
+    pub const H: Self = Self(8);
 }
 
 impl From<u8> for NodeType {
     fn from(n: u8) -> Self {
-        use NodeType::*;
-        match n {
-            1 => B,
-            2 => P,
-            4 => M,
-            8 => H,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<NodeType> for u8 {
     fn from(n: NodeType) -> Self {
-        use NodeType as N;
-        match n {
-            N::B => 1,
-            N::P => 2,
-            N::M => 4,
-            N::H => 8,
-            N::Unknown(n) => n,
-        }
+        n.0
     }
 }
 
 /// AutoConfigure option values
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u8)]
-pub enum AutoConfig {
+#[repr(transparent)]
+pub struct AutoConfig(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl AutoConfig {
     /// Do not autoconfig
-    DoNotAutoConfigure = 0,
+    pub const DoNotAutoConfigure: Self = Self(0);
     /// autoconfig
-    AutoConfigure = 1,
+    pub const AutoConfigure: Self = Self(1);
 }
 
-impl TryFrom<u8> for AutoConfig {
-    type Error = crate::error::DecodeError;
+impl From<u8> for AutoConfig {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(AutoConfig::DoNotAutoConfigure),
-            1 => Ok(AutoConfig::AutoConfigure),
-            n => Err(super::DecodeError::InvalidData(
-                n as u32,
-                "invalid number in disable SLAAC autoconfig",
-            )),
-        }
+impl From<AutoConfig> for u8 {
+    fn from(a: AutoConfig) -> Self {
+        a.0
     }
 }
 
@@ -771,7 +759,7 @@ pub(crate) fn decode_inner(
         OptionCode::TimezoneDatabaseString => TimezoneDatabaseString(decoder.read_string(len)?),
         OptionCode::Ipv6OnlyPreferred => Ipv6OnlyPreferred(decoder.read_u32()?),
         OptionCode::CaptivePortal => CaptivePortal(decoder.read_str(len)?.to_string()),
-        OptionCode::DisableSLAAC => DisableSLAAC(decoder.read_u8()?.try_into()?),
+        OptionCode::DisableSLAAC => DisableSLAAC(decoder.read_u8()?.into()),
         OptionCode::SubnetSelection => SubnetSelection(decoder.read_ipv4(len)?),
         OptionCode::DomainSearch => DomainSearch(decoder.read_domains(len)?),
         OptionCode::SipServers => SipServers(decode_sip_servers(len, decoder)?),
@@ -1294,7 +1282,7 @@ impl Encodable for DhcpOption {
             O::DisableSLAAC(val) => {
                 e.write_u8(code.into())?;
                 e.write_u8(1)?;
-                e.write_u8(*val as u8)?;
+                e.write_u8(val.0)?;
             }
             // not yet implemented
             O::Unknown(opt) => {
@@ -1357,95 +1345,58 @@ impl Encodable for UnknownOption {
 /// <https://datatracker.ietf.org/doc/html/rfc2131#section-3.1>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MessageType {
+#[repr(transparent)]
+pub struct MessageType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl MessageType {
     /// DHCPDiscover
-    Discover,
+    pub const Discover: Self = Self(1);
     /// DHCPOffer
-    Offer,
+    pub const Offer: Self = Self(2);
     /// DHCPRequest
-    Request,
+    pub const Request: Self = Self(3);
     /// DHCPDecline
-    Decline,
+    pub const Decline: Self = Self(4);
     /// DHCPAck
-    Ack,
+    pub const Ack: Self = Self(5);
     /// DHCPNak
-    Nak,
+    pub const Nak: Self = Self(6);
     /// DHCPRelease
-    Release,
+    pub const Release: Self = Self(7);
     /// DHCPInform
-    Inform,
+    pub const Inform: Self = Self(8);
     /// DHCPForceRenew - <https://www.rfc-editor.org/rfc/rfc3203.html>
-    ForceRenew,
+    pub const ForceRenew: Self = Self(9);
     /// DHCPLeaseQuery - <https://www.rfc-editor.org/rfc/rfc4388#section-6.1>
-    LeaseQuery,
+    pub const LeaseQuery: Self = Self(10);
     /// DHCPLeaseUnassigned
-    LeaseUnassigned,
+    pub const LeaseUnassigned: Self = Self(11);
     /// DHCPLeaseUnknown
-    LeaseUnknown,
+    pub const LeaseUnknown: Self = Self(12);
     /// DHCPLeaseActive
-    LeaseActive,
+    pub const LeaseActive: Self = Self(13);
     /// DHCPBulkLeaseQuery - <https://www.rfc-editor.org/rfc/rfc6926.html>
-    BulkLeaseQuery,
+    pub const BulkLeaseQuery: Self = Self(14);
     /// DHCPLeaseQueryDone
-    LeaseQueryDone,
+    pub const LeaseQueryDone: Self = Self(15);
     /// DHCPActiveLeaseQuery - <https://www.rfc-editor.org/rfc/rfc7724.html>
-    ActiveLeaseQuery,
+    pub const ActiveLeaseQuery: Self = Self(16);
     /// DHCPLeaseQueryStatus
-    LeaseQueryStatus,
+    pub const LeaseQueryStatus: Self = Self(17);
     /// DHCPTLS
-    Tls,
-    /// an unknown message type
-    Unknown(u8),
+    pub const Tls: Self = Self(18);
 }
 
 impl From<u8> for MessageType {
     fn from(n: u8) -> Self {
-        match n {
-            1 => MessageType::Discover,
-            2 => MessageType::Offer,
-            3 => MessageType::Request,
-            4 => MessageType::Decline,
-            5 => MessageType::Ack,
-            6 => MessageType::Nak,
-            7 => MessageType::Release,
-            8 => MessageType::Inform,
-            9 => MessageType::ForceRenew,
-            10 => MessageType::LeaseQuery,
-            11 => MessageType::LeaseUnassigned,
-            12 => MessageType::LeaseUnknown,
-            13 => MessageType::LeaseActive,
-            14 => MessageType::BulkLeaseQuery,
-            15 => MessageType::LeaseQueryDone,
-            16 => MessageType::ActiveLeaseQuery,
-            17 => MessageType::LeaseQueryStatus,
-            18 => MessageType::Tls,
-            n => MessageType::Unknown(n),
-        }
+        Self(n)
     }
 }
+
 impl From<MessageType> for u8 {
     fn from(m: MessageType) -> Self {
-        match m {
-            MessageType::Discover => 1,
-            MessageType::Offer => 2,
-            MessageType::Request => 3,
-            MessageType::Decline => 4,
-            MessageType::Ack => 5,
-            MessageType::Nak => 6,
-            MessageType::Release => 7,
-            MessageType::Inform => 8,
-            MessageType::ForceRenew => 9,
-            MessageType::LeaseQuery => 10,
-            MessageType::LeaseUnassigned => 11,
-            MessageType::LeaseUnknown => 12,
-            MessageType::LeaseActive => 13,
-            MessageType::BulkLeaseQuery => 14,
-            MessageType::LeaseQueryDone => 15,
-            MessageType::ActiveLeaseQuery => 16,
-            MessageType::LeaseQueryStatus => 17,
-            MessageType::Tls => 18,
-            MessageType::Unknown(n) => n,
-        }
+        m.0
     }
 }
 

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -177,7 +177,10 @@ impl Decodable for RelayInfo {
             code => {
                 let length = d.read_u8()?;
                 let bytes = d.read_slice(length as usize)?.to_vec();
-                Unknown(UnknownInfo { code: code.0, data: bytes })
+                Unknown(UnknownInfo {
+                    code: code.0,
+                    data: bytes,
+                })
             }
         })
     }

--- a/src/v4/relay.rs
+++ b/src/v4/relay.rs
@@ -174,10 +174,10 @@ impl Decodable for RelayInfo {
                 })
             }
             // not yet implemented
-            RelayCode::Unknown(code) => {
+            code => {
                 let length = d.read_u8()?;
                 let bytes = d.read_slice(length as usize)?.to_vec();
-                Unknown(UnknownInfo { code, data: bytes })
+                Unknown(UnknownInfo { code: code.0, data: bytes })
             }
         })
     }
@@ -294,21 +294,23 @@ impl UnknownInfo {
 /// relay code, represented as a u8
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum RelayCode {
-    AgentCircuitId,
-    AgentRemoteId,
-    DocsisDeviceClass,
-    LinkSelection,
-    SubscriberId,
-    RadiusAttributes,
-    Authentication,
-    VendorSpecificInformation,
-    RelayAgentFlags,
-    ServerIdentifierOverride,
-    VirtualSubnet,
-    VirtualSubnetControl,
-    /// unknown/unimplemented message type
-    Unknown(u8),
+#[repr(transparent)]
+pub struct RelayCode(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl RelayCode {
+    pub const AgentCircuitId: Self = Self(1);
+    pub const AgentRemoteId: Self = Self(2);
+    pub const DocsisDeviceClass: Self = Self(4);
+    pub const LinkSelection: Self = Self(5);
+    pub const SubscriberId: Self = Self(6);
+    pub const RadiusAttributes: Self = Self(7);
+    pub const Authentication: Self = Self(8);
+    pub const VendorSpecificInformation: Self = Self(9);
+    pub const RelayAgentFlags: Self = Self(10);
+    pub const ServerIdentifierOverride: Self = Self(11);
+    pub const VirtualSubnet: Self = Self(151);
+    pub const VirtualSubnetControl: Self = Self(152);
 }
 
 impl PartialOrd for RelayCode {
@@ -319,48 +321,18 @@ impl PartialOrd for RelayCode {
 
 impl Ord for RelayCode {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        u8::from(*self).cmp(&u8::from(*other))
+        self.0.cmp(&other.0)
     }
 }
 
 impl From<u8> for RelayCode {
     fn from(n: u8) -> Self {
-        use RelayCode::*;
-        match n {
-            1 => AgentCircuitId,
-            2 => AgentRemoteId,
-            4 => DocsisDeviceClass,
-            5 => LinkSelection,
-            6 => SubscriberId,
-            7 => RadiusAttributes,
-            8 => Authentication,
-            9 => VendorSpecificInformation,
-            10 => RelayAgentFlags,
-            11 => ServerIdentifierOverride,
-            151 => VirtualSubnet,
-            152 => VirtualSubnetControl,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 impl From<RelayCode> for u8 {
     fn from(code: RelayCode) -> Self {
-        use RelayCode as R;
-        match code {
-            R::AgentCircuitId => 1,
-            R::AgentRemoteId => 2,
-            R::DocsisDeviceClass => 4,
-            R::LinkSelection => 5,
-            R::SubscriberId => 6,
-            R::RadiusAttributes => 7,
-            R::Authentication => 8,
-            R::VendorSpecificInformation => 9,
-            R::RelayAgentFlags => 10,
-            R::ServerIdentifierOverride => 11,
-            R::VirtualSubnet => 151,
-            R::VirtualSubnetControl => 152,
-            R::Unknown(n) => n,
-        }
+        code.0
     }
 }
 
@@ -375,7 +347,7 @@ impl From<&RelayInfo> for RelayCode {
             R::SubscriberId(_) => RelayCode::SubscriberId,
             R::RelayAgentFlags(_) => RelayCode::RelayAgentFlags,
             R::ServerIdentifierOverride(_) => RelayCode::ServerIdentifierOverride,
-            R::Unknown(unknown) => RelayCode::Unknown(unknown.code),
+            R::Unknown(unknown) => RelayCode(unknown.code),
         }
     }
 }
@@ -448,7 +420,7 @@ mod tests {
     #[test]
     fn test_unknown() -> Result<()> {
         test_opt(
-            RelayInfo::Unknown(UnknownInfo::new(RelayCode::Unknown(149), vec![1, 2, 3, 4])),
+            RelayInfo::Unknown(UnknownInfo::new(RelayCode(149), vec![1, 2, 3, 4])),
             vec![149, 4, 1, 2, 3, 4],
         )?;
 

--- a/src/v6/htype.rs
+++ b/src/v6/htype.rs
@@ -11,177 +11,98 @@ use serde::{Deserialize, Serialize};
 /// Hardware type of message
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Hash, Clone, PartialEq, Eq)]
-pub enum HType {
+#[repr(transparent)]
+pub struct HType(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl HType {
     /// 1 Ethernet
-    Eth,
+    pub const Eth: Self = Self(1);
     /// 2 Experimental Ethernet
-    ExperimentalEth,
+    pub const ExperimentalEth: Self = Self(2);
     /// 3 Amateur Radio AX25
-    AmRadioAX25,
+    pub const AmRadioAX25: Self = Self(3);
     /// 4 Proteon Token Ring
-    ProteonTokenRing,
+    pub const ProteonTokenRing: Self = Self(4);
     /// 5 Chaos
-    Chaos,
+    pub const Chaos: Self = Self(5);
     /// 6 IEEE.802
-    IEEE802,
+    pub const IEEE802: Self = Self(6);
     /// 7 ARCNET
-    ARCNET,
+    pub const ARCNET: Self = Self(7);
     /// 8 Hyperchannel
-    Hyperchannel,
+    pub const Hyperchannel: Self = Self(8);
     /// 9 LANSTAR
-    Lanstar,
+    pub const Lanstar: Self = Self(9);
     /// 10 Autonet Short Addr
-    AutonetShortAddr,
+    pub const AutonetShortAddr: Self = Self(10);
     /// 11 LocalTalk
-    LocalTalk,
+    pub const LocalTalk: Self = Self(11);
     /// 12 LocalNet
-    LocalNet,
+    pub const LocalNet: Self = Self(12);
     /// 13 Ultralink
-    Ultralink,
+    pub const Ultralink: Self = Self(13);
     /// 14 SMDS
-    SMDS,
+    pub const SMDS: Self = Self(14);
     /// 15 FrameRelay
-    FrameRelay,
+    pub const FrameRelay: Self = Self(15);
     /// 17 HDLC
-    HDLC,
+    pub const HDLC: Self = Self(17);
     /// 18 FibreChannel
-    FibreChannel,
+    pub const FibreChannel: Self = Self(18);
     /// 20 SerialLine
-    SerialLine,
+    pub const SerialLine: Self = Self(20);
     /// 22 Mil STD
-    MilStd188220,
+    pub const MilStd188220: Self = Self(22);
     /// 23 Metricom
-    Metricom,
+    pub const Metricom: Self = Self(23);
     /// 24 IEEE1394.1995
-    IEEE13941995,
+    pub const IEEE13941995: Self = Self(24);
     /// 25 MAPOS
-    MAPOS,
+    pub const MAPOS: Self = Self(25);
     /// 26 Twinaxial
-    Twinaxial,
+    pub const Twinaxial: Self = Self(26);
     /// 27 EUI64
-    EUI64,
+    pub const EUI64: Self = Self(27);
     /// 28 HIPARP
-    HIPARP,
+    pub const HIPARP: Self = Self(28);
     /// 29 IP and ARP over ISO 7816-3
-    IPandARPoverISO78163,
+    pub const IPandARPoverISO78163: Self = Self(29);
     /// 30 ARPSec
-    ARPSec,
+    pub const ARPSec: Self = Self(30);
     /// 31 IPsec tunnel
-    IPsecTunnel,
+    pub const IPsecTunnel: Self = Self(31);
     /// 32 Infiniband
-    Infiniband,
+    pub const Infiniband: Self = Self(32);
     /// 33 TIA-102 Project 25 Common Air Interface (CAI)
-    CAI,
+    pub const CAI: Self = Self(33);
     /// 34 WeigandInt
-    WiegandInt,
+    pub const WiegandInt: Self = Self(34);
     /// 35 PureIP
-    PureIP,
+    pub const PureIP: Self = Self(35);
     /// 36 HW_EXP1
-    HWExp1,
+    pub const HWExp1: Self = Self(36);
     /// 37 HFI
-    HFI,
-    /// 38 Unified BUS(UB),
-    UB,
+    pub const HFI: Self = Self(37);
+    /// 38 Unified BUS(UB)
+    pub const UB: Self = Self(38);
     /// 256 HW_EXP2
-    HWExp2,
+    pub const HWExp2: Self = Self(256);
     /// 257 AEthernet
-    AEthernet,
+    pub const AEthernet: Self = Self(257);
     /// 65535 Reserved
-    Reserved,
-    /// Unknown or not yet implemented htype
-    Unknown(u16),
+    pub const Reserved: Self = Self(65535);
 }
+
 impl From<u16> for HType {
     fn from(n: u16) -> Self {
-        use HType::*;
-        match n {
-            1 => Eth,
-            2 => ExperimentalEth,
-            3 => AmRadioAX25,
-            4 => ProteonTokenRing,
-            5 => Chaos,
-            6 => IEEE802,
-            7 => ARCNET,
-            8 => Hyperchannel,
-            9 => Lanstar,
-            10 => AutonetShortAddr,
-            11 => LocalTalk,
-            12 => LocalNet,
-            13 => Ultralink,
-            14 => SMDS,
-            15 => FrameRelay,
-            17 => HDLC,
-            18 => FibreChannel,
-            20 => SerialLine,
-            22 => MilStd188220,
-            23 => Metricom,
-            24 => IEEE13941995,
-            25 => MAPOS,
-            26 => Twinaxial,
-            27 => EUI64,
-            28 => HIPARP,
-            29 => IPandARPoverISO78163,
-            30 => ARPSec,
-            31 => IPsecTunnel,
-            32 => Infiniband,
-            33 => CAI,
-            34 => WiegandInt,
-            35 => PureIP,
-            36 => HWExp1,
-            37 => HFI,
-            38 => UB,
-            256 => HWExp2,
-            257 => AEthernet,
-            65535 => Reserved,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<HType> for u16 {
     fn from(n: HType) -> Self {
-        use HType as H;
-        match n {
-            H::Eth => 1,
-            H::ExperimentalEth => 2,
-            H::AmRadioAX25 => 3,
-            H::ProteonTokenRing => 4,
-            H::Chaos => 5,
-            H::IEEE802 => 6,
-            H::ARCNET => 7,
-            H::Hyperchannel => 8,
-            H::Lanstar => 9,
-            H::AutonetShortAddr => 10,
-            H::LocalTalk => 11,
-            H::LocalNet => 12,
-            H::Ultralink => 13,
-            H::SMDS => 14,
-            H::FrameRelay => 15,
-            H::HDLC => 17,
-            H::FibreChannel => 18,
-            H::SerialLine => 20,
-            H::MilStd188220 => 22,
-            H::Metricom => 23,
-            H::IEEE13941995 => 24,
-            H::MAPOS => 25,
-            H::Twinaxial => 26,
-            H::EUI64 => 27,
-            H::HIPARP => 28,
-            H::IPandARPoverISO78163 => 29,
-            H::ARPSec => 30,
-            H::IPsecTunnel => 31,
-            H::Infiniband => 32,
-            H::CAI => 33,
-            H::WiegandInt => 34,
-            H::PureIP => 35,
-            H::HWExp1 => 36,
-            H::HFI => 37,
-            H::UB => 38,
-            H::HWExp2 => 256,
-            H::AEthernet => 257,
-            H::Reserved => 65535,
-            H::Unknown(n) => n,
-        }
+        n.0
     }
 }
 

--- a/src/v6/mod.rs
+++ b/src/v6/mod.rs
@@ -220,125 +220,69 @@ impl Message {
 /// <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MessageType {
+#[repr(transparent)]
+pub struct MessageType(pub u8);
+
+#[allow(non_upper_case_globals)]
+impl MessageType {
     // RFC 3315
     /// client solicit - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Solicit,
+    pub const Solicit: Self = Self(1);
     /// server advertise - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Advertise,
+    pub const Advertise: Self = Self(2);
     /// request - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Request,
+    pub const Request: Self = Self(3);
     /// confirm - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Confirm,
+    pub const Confirm: Self = Self(4);
     /// renew - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Renew,
+    pub const Renew: Self = Self(5);
     /// rebind - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Rebind,
+    pub const Rebind: Self = Self(6);
     /// reply - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Reply,
+    pub const Reply: Self = Self(7);
     /// release message type - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Release,
+    pub const Release: Self = Self(8);
     /// decline - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Decline,
+    pub const Decline: Self = Self(9);
     /// reconfigure - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    Reconfigure,
+    pub const Reconfigure: Self = Self(10);
     /// information request - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    InformationRequest,
+    pub const InformationRequest: Self = Self(11);
     /// relay forward - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    RelayForw,
+    pub const RelayForw: Self = Self(12);
     /// relay reply - <https://datatracker.ietf.org/doc/html/rfc8415#section-7.3>
-    RelayRepl,
+    pub const RelayRepl: Self = Self(13);
     // RFC 5007
     /// lease query - <https://datatracker.ietf.org/doc/html/rfc5007#section-4.2.1>
-    LeaseQuery,
+    pub const LeaseQuery: Self = Self(14);
     /// lease query reply - <https://datatracker.ietf.org/doc/html/rfc5007#section-4.2.2>
-    LeaseQueryReply,
+    pub const LeaseQueryReply: Self = Self(15);
     // RFC 5460
     /// lease query done - <https://datatracker.ietf.org/doc/html/rfc5460#section-5.2.2>
-    LeaseQueryDone,
+    pub const LeaseQueryDone: Self = Self(16);
     /// lease query data - <https://datatracker.ietf.org/doc/html/rfc5460#section-5.2.1>
-    LeaseQueryData,
+    pub const LeaseQueryData: Self = Self(17);
     // RFC 6977
     /// reconfigure request - <https://datatracker.ietf.org/doc/html/rfc6977#section-6.2.1>
-    ReconfigureRequest,
+    pub const ReconfigureRequest: Self = Self(18);
     /// reconfigure reply - <https://datatracker.ietf.org/doc/html/rfc6977#section-6.2.2>
-    ReconfigureReply,
+    pub const ReconfigureReply: Self = Self(19);
     // RFC 7341
     /// dhcpv4 query - <https://datatracker.ietf.org/doc/html/rfc7341#section-6.2>
-    DHCPv4Query,
+    pub const DHCPv4Query: Self = Self(20);
     /// dhcpv4 response - <https://datatracker.ietf.org/doc/html/rfc7341#section-6.2>
-    DHCPv4Response,
-    /// unknown/unimplemented message type
-    Unknown(u8),
+    pub const DHCPv4Response: Self = Self(21);
 }
 
 impl From<u8> for MessageType {
     fn from(n: u8) -> Self {
-        use MessageType::*;
-        match n {
-            // RFC 3315
-            1 => Solicit,
-            2 => Advertise,
-            3 => Request,
-            4 => Confirm,
-            5 => Renew,
-            6 => Rebind,
-            7 => Reply,
-            8 => Release,
-            9 => Decline,
-            10 => Reconfigure,
-            11 => InformationRequest,
-            12 => RelayForw,
-            13 => RelayRepl,
-            // RFC 5007
-            14 => LeaseQuery,
-            15 => LeaseQueryReply,
-            // RFC 5460
-            16 => LeaseQueryDone,
-            17 => LeaseQueryData,
-            // RFC 6977
-            18 => ReconfigureRequest,
-            19 => ReconfigureReply,
-            // RFC 7341
-            20 => DHCPv4Query,
-            21 => DHCPv4Response,
-            n => Unknown(n),
-        }
+        Self(n)
     }
 }
 
 impl From<MessageType> for u8 {
     fn from(m: MessageType) -> Self {
-        use MessageType as M;
-        match m {
-            // RFC 3315
-            M::Solicit => 1,
-            M::Advertise => 2,
-            M::Request => 3,
-            M::Confirm => 4,
-            M::Renew => 5,
-            M::Rebind => 6,
-            M::Reply => 7,
-            M::Release => 8,
-            M::Decline => 9,
-            M::Reconfigure => 10,
-            M::InformationRequest => 11,
-            M::RelayForw => 12,
-            M::RelayRepl => 13,
-            // RFC 5007
-            M::LeaseQuery => 14,
-            M::LeaseQueryReply => 15,
-            // RFC 5460
-            M::LeaseQueryDone => 16,
-            M::LeaseQueryData => 17,
-            // RFC 6977
-            M::ReconfigureRequest => 18,
-            M::ReconfigureReply => 19,
-            // RFC 7341
-            M::DHCPv4Query => 20,
-            M::DHCPv4Response => 21,
-            M::Unknown(n) => n,
-        }
+        m.0
     }
 }
 

--- a/src/v6/option_codes.rs
+++ b/src/v6/option_codes.rs
@@ -6,427 +6,156 @@ use serde::{Deserialize, Serialize};
 /// option code type
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OptionCode {
-    ClientId,
-    ServerId,
-    IANA,
-    IATA,
-    IAAddr,
-    ORO,
-    Preference,
-    ElapsedTime,
-    RelayMsg,
-    Authentication,
-    ServerUnicast,
-    StatusCode,
-    RapidCommit,
-    UserClass,
-    VendorClass,
-    VendorOpts,
-    InterfaceId,
-    ReconfMsg,
-    ReconfAccept,
-    SipServerD,
-    SipServerA,
-    DomainNameServers,
-    DomainSearchList,
-    IAPD,
-    IAPrefix,
-    NisServers,
-    NispServers,
-    NisDomainName,
-    NispDomainName,
-    SntpServers,
-    InformationRefreshTime,
-    BcmcsServerD,
-    BcmcsServerA,
-    GeoconfCivic,
-    RemoteId,
-    SubscriberId,
-    ClientFqdn,
-    PanaAgent,
-    NewPosixTimezone,
-    NewTzdbTimezone,
-    ERO,
-    LqQuery,
-    ClientData,
-    CltTime,
-    LqRelayData,
-    LqClientLink,
-    Mip6Hnidf,
-    Mip6Vdinf,
-    V6Lost,
-    CapwapAcV6,
-    RelayId,
-    Ipv6AddressMoS,
-    Ipv6FQDNMoS,
-    NtpServer,
-    V6AccessDomain,
-    SipUaCsList,
-    OptBootfileUrl,
-    OptBootfileParam,
-    ClientArchType,
-    Nii,
-    Geolocation,
-    AftrName,
-    ErpLocalDomainName,
-    Rsoo,
-    PdExclude,
-    Vss,
-    Mip6Idinf,
-    Mip6Udinf,
-    Mip6Hnp,
-    Mip6Haa,
-    Mip6Haf,
-    RdnssSelection,
-    KrbPrincipalName,
-    KrbRealmName,
-    KrbDefaultRealmName,
-    KrbKdc,
-    ClientLinklayerAddr,
-    LinkAddress,
-    Radius,
-    SolMaxRt,
-    InfMaxRt,
-    Addrsel,
-    AddrselTable,
-    V6PcpServer,
-    Dhcpv4Msg,
-    Dhcp4ODhcp6Server,
-    S46Rule,
-    S46Br,
-    S46Dmr,
-    S46V4v6bind,
-    S46Portparams,
-    S46ContMape,
-    S46ContMapt,
-    S46ContLw,
-    _4Rd,
-    _4RdMapRule,
-    _4RdNonMapRule,
-    LqBaseTime,
-    LqStartTime,
-    LqEndTime,
-    DhcpCaptivePortal,
-    MplParameters,
-    AniAtt,
-    AniNetworkName,
-    AniApName,
-    AniApBssid,
-    AniOperatorId,
-    AniOperatorRealm,
-    S46Priority,
-    MudUrlV6,
-    V6Prefix64,
-    FBindingStatus,
-    FConnectFlags,
-    Fdnsremovalinfo,
-    FDNSHostName,
-    FDNSZoneName,
-    Fdnsflags,
-    Fexpirationtime,
-    FMaxUnackedBndupd,
-    FMclt,
-    FPartnerLifetime,
-    FPartnerLifetimeSent,
-    FPartnerDownTime,
-    FPartnerRawCltTime,
-    FProtocolVersion,
-    FKeepaliveTime,
-    FReconfigureData,
-    FRelationshipName,
-    FServerFlags,
-    FServerState,
-    FStartTimeOfState,
-    FStateExpirationTime,
-    RelayPort,
-    Ipv6AddressANDSF,
-    Unknown(u16),
+#[repr(transparent)]
+pub struct OptionCode(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl OptionCode {
+    pub const ClientId: Self = Self(1);
+    pub const ServerId: Self = Self(2);
+    pub const IANA: Self = Self(3);
+    pub const IATA: Self = Self(4);
+    pub const IAAddr: Self = Self(5);
+    pub const ORO: Self = Self(6);
+    pub const Preference: Self = Self(7);
+    pub const ElapsedTime: Self = Self(8);
+    pub const RelayMsg: Self = Self(9);
+    pub const Authentication: Self = Self(11);
+    pub const ServerUnicast: Self = Self(12);
+    pub const StatusCode: Self = Self(13);
+    pub const RapidCommit: Self = Self(14);
+    pub const UserClass: Self = Self(15);
+    pub const VendorClass: Self = Self(16);
+    pub const VendorOpts: Self = Self(17);
+    pub const InterfaceId: Self = Self(18);
+    pub const ReconfMsg: Self = Self(19);
+    pub const ReconfAccept: Self = Self(20);
+    pub const SipServerD: Self = Self(21);
+    pub const SipServerA: Self = Self(22);
+    pub const DomainNameServers: Self = Self(23);
+    pub const DomainSearchList: Self = Self(24);
+    pub const IAPD: Self = Self(25);
+    pub const IAPrefix: Self = Self(26);
+    pub const NisServers: Self = Self(27);
+    pub const NispServers: Self = Self(28);
+    pub const NisDomainName: Self = Self(29);
+    pub const NispDomainName: Self = Self(30);
+    pub const SntpServers: Self = Self(31);
+    pub const InformationRefreshTime: Self = Self(32);
+    pub const BcmcsServerD: Self = Self(33);
+    pub const BcmcsServerA: Self = Self(34);
+    pub const GeoconfCivic: Self = Self(36);
+    pub const RemoteId: Self = Self(37);
+    pub const SubscriberId: Self = Self(38);
+    pub const ClientFqdn: Self = Self(39);
+    pub const PanaAgent: Self = Self(40);
+    pub const NewPosixTimezone: Self = Self(41);
+    pub const NewTzdbTimezone: Self = Self(42);
+    pub const ERO: Self = Self(43);
+    pub const LqQuery: Self = Self(44);
+    pub const ClientData: Self = Self(45);
+    pub const CltTime: Self = Self(46);
+    pub const LqRelayData: Self = Self(47);
+    pub const LqClientLink: Self = Self(48);
+    pub const Mip6Hnidf: Self = Self(49);
+    pub const Mip6Vdinf: Self = Self(50);
+    pub const V6Lost: Self = Self(51);
+    pub const CapwapAcV6: Self = Self(52);
+    pub const RelayId: Self = Self(53);
+    pub const Ipv6AddressMoS: Self = Self(54);
+    pub const Ipv6FQDNMoS: Self = Self(55);
+    pub const NtpServer: Self = Self(56);
+    pub const V6AccessDomain: Self = Self(57);
+    pub const SipUaCsList: Self = Self(58);
+    pub const OptBootfileUrl: Self = Self(59);
+    pub const OptBootfileParam: Self = Self(60);
+    pub const ClientArchType: Self = Self(61);
+    pub const Nii: Self = Self(62);
+    pub const Geolocation: Self = Self(63);
+    pub const AftrName: Self = Self(64);
+    pub const ErpLocalDomainName: Self = Self(65);
+    pub const Rsoo: Self = Self(66);
+    pub const PdExclude: Self = Self(67);
+    pub const Vss: Self = Self(68);
+    pub const Mip6Idinf: Self = Self(69);
+    pub const Mip6Udinf: Self = Self(70);
+    pub const Mip6Hnp: Self = Self(71);
+    pub const Mip6Haa: Self = Self(72);
+    pub const Mip6Haf: Self = Self(73);
+    pub const RdnssSelection: Self = Self(74);
+    pub const KrbPrincipalName: Self = Self(75);
+    pub const KrbRealmName: Self = Self(76);
+    pub const KrbDefaultRealmName: Self = Self(77);
+    pub const KrbKdc: Self = Self(78);
+    pub const ClientLinklayerAddr: Self = Self(79);
+    pub const LinkAddress: Self = Self(80);
+    pub const Radius: Self = Self(81);
+    pub const SolMaxRt: Self = Self(82);
+    pub const InfMaxRt: Self = Self(83);
+    pub const Addrsel: Self = Self(84);
+    pub const AddrselTable: Self = Self(85);
+    pub const V6PcpServer: Self = Self(86);
+    pub const Dhcpv4Msg: Self = Self(87);
+    pub const Dhcp4ODhcp6Server: Self = Self(88);
+    pub const S46Rule: Self = Self(89);
+    pub const S46Br: Self = Self(90);
+    pub const S46Dmr: Self = Self(91);
+    pub const S46V4v6bind: Self = Self(92);
+    pub const S46Portparams: Self = Self(93);
+    pub const S46ContMape: Self = Self(94);
+    pub const S46ContMapt: Self = Self(95);
+    pub const S46ContLw: Self = Self(96);
+    pub const _4Rd: Self = Self(97);
+    pub const _4RdMapRule: Self = Self(98);
+    pub const _4RdNonMapRule: Self = Self(99);
+    pub const LqBaseTime: Self = Self(100);
+    pub const LqStartTime: Self = Self(101);
+    pub const LqEndTime: Self = Self(102);
+    pub const DhcpCaptivePortal: Self = Self(103);
+    pub const MplParameters: Self = Self(104);
+    pub const AniAtt: Self = Self(105);
+    pub const AniNetworkName: Self = Self(106);
+    pub const AniApName: Self = Self(107);
+    pub const AniApBssid: Self = Self(108);
+    pub const AniOperatorId: Self = Self(109);
+    pub const AniOperatorRealm: Self = Self(110);
+    pub const S46Priority: Self = Self(111);
+    pub const MudUrlV6: Self = Self(112);
+    pub const V6Prefix64: Self = Self(113);
+    pub const FBindingStatus: Self = Self(114);
+    pub const FConnectFlags: Self = Self(115);
+    pub const Fdnsremovalinfo: Self = Self(116);
+    pub const FDNSHostName: Self = Self(117);
+    pub const FDNSZoneName: Self = Self(118);
+    pub const Fdnsflags: Self = Self(119);
+    pub const Fexpirationtime: Self = Self(120);
+    pub const FMaxUnackedBndupd: Self = Self(121);
+    pub const FMclt: Self = Self(122);
+    pub const FPartnerLifetime: Self = Self(123);
+    pub const FPartnerLifetimeSent: Self = Self(124);
+    pub const FPartnerDownTime: Self = Self(125);
+    pub const FPartnerRawCltTime: Self = Self(126);
+    pub const FProtocolVersion: Self = Self(127);
+    pub const FKeepaliveTime: Self = Self(128);
+    pub const FReconfigureData: Self = Self(129);
+    pub const FRelationshipName: Self = Self(130);
+    pub const FServerFlags: Self = Self(131);
+    pub const FServerState: Self = Self(132);
+    pub const FStartTimeOfState: Self = Self(133);
+    pub const FStateExpirationTime: Self = Self(134);
+    pub const RelayPort: Self = Self(135);
+    pub const Ipv6AddressANDSF: Self = Self(143);
 }
 
 impl From<OptionCode> for u16 {
     fn from(opt: OptionCode) -> Self {
-        use OptionCode as O;
-        match opt {
-            O::ClientId => 1,
-            O::ServerId => 2,
-            O::IANA => 3,
-            O::IATA => 4,
-            O::IAAddr => 5,
-            O::ORO => 6,
-            O::Preference => 7,
-            O::ElapsedTime => 8,
-            O::RelayMsg => 9,
-            O::Authentication => 11,
-            O::ServerUnicast => 12,
-            O::StatusCode => 13,
-            O::RapidCommit => 14,
-            O::UserClass => 15,
-            O::VendorClass => 16,
-            O::VendorOpts => 17,
-            O::InterfaceId => 18,
-            O::ReconfMsg => 19,
-            O::ReconfAccept => 20,
-            O::SipServerD => 21,
-            O::SipServerA => 22,
-            O::DomainNameServers => 23,
-            O::DomainSearchList => 24,
-            O::IAPD => 25,
-            O::IAPrefix => 26,
-            O::NisServers => 27,
-            O::NispServers => 28,
-            O::NisDomainName => 29,
-            O::NispDomainName => 30,
-            O::SntpServers => 31,
-            O::InformationRefreshTime => 32,
-            O::BcmcsServerD => 33,
-            O::BcmcsServerA => 34,
-            O::GeoconfCivic => 36,
-            O::RemoteId => 37,
-            O::SubscriberId => 38,
-            O::ClientFqdn => 39,
-            O::PanaAgent => 40,
-            O::NewPosixTimezone => 41,
-            O::NewTzdbTimezone => 42,
-            O::ERO => 43,
-            O::LqQuery => 44,
-            O::ClientData => 45,
-            O::CltTime => 46,
-            O::LqRelayData => 47,
-            O::LqClientLink => 48,
-            O::Mip6Hnidf => 49,
-            O::Mip6Vdinf => 50,
-            O::V6Lost => 51,
-            O::CapwapAcV6 => 52,
-            O::RelayId => 53,
-            O::Ipv6AddressMoS => 54,
-            O::Ipv6FQDNMoS => 55,
-            O::NtpServer => 56,
-            O::V6AccessDomain => 57,
-            O::SipUaCsList => 58,
-            O::OptBootfileUrl => 59,
-            O::OptBootfileParam => 60,
-            O::ClientArchType => 61,
-            O::Nii => 62,
-            O::Geolocation => 63,
-            O::AftrName => 64,
-            O::ErpLocalDomainName => 65,
-            O::Rsoo => 66,
-            O::PdExclude => 67,
-            O::Vss => 68,
-            O::Mip6Idinf => 69,
-            O::Mip6Udinf => 70,
-            O::Mip6Hnp => 71,
-            O::Mip6Haa => 72,
-            O::Mip6Haf => 73,
-            O::RdnssSelection => 74,
-            O::KrbPrincipalName => 75,
-            O::KrbRealmName => 76,
-            O::KrbDefaultRealmName => 77,
-            O::KrbKdc => 78,
-            O::ClientLinklayerAddr => 79,
-            O::LinkAddress => 80,
-            O::Radius => 81,
-            O::SolMaxRt => 82,
-            O::InfMaxRt => 83,
-            O::Addrsel => 84,
-            O::AddrselTable => 85,
-            O::V6PcpServer => 86,
-            O::Dhcpv4Msg => 87,
-            O::Dhcp4ODhcp6Server => 88,
-            O::S46Rule => 89,
-            O::S46Br => 90,
-            O::S46Dmr => 91,
-            O::S46V4v6bind => 92,
-            O::S46Portparams => 93,
-            O::S46ContMape => 94,
-            O::S46ContMapt => 95,
-            O::S46ContLw => 96,
-            O::_4Rd => 97,
-            O::_4RdMapRule => 98,
-            O::_4RdNonMapRule => 99,
-            O::LqBaseTime => 100,
-            O::LqStartTime => 101,
-            O::LqEndTime => 102,
-            O::DhcpCaptivePortal => 103,
-            O::MplParameters => 104,
-            O::AniAtt => 105,
-            O::AniNetworkName => 106,
-            O::AniApName => 107,
-            O::AniApBssid => 108,
-            O::AniOperatorId => 109,
-            O::AniOperatorRealm => 110,
-            O::S46Priority => 111,
-            O::MudUrlV6 => 112,
-            O::V6Prefix64 => 113,
-            O::FBindingStatus => 114,
-            O::FConnectFlags => 115,
-            O::Fdnsremovalinfo => 116,
-            O::FDNSHostName => 117,
-            O::FDNSZoneName => 118,
-            O::Fdnsflags => 119,
-            O::Fexpirationtime => 120,
-            O::FMaxUnackedBndupd => 121,
-            O::FMclt => 122,
-            O::FPartnerLifetime => 123,
-            O::FPartnerLifetimeSent => 124,
-            O::FPartnerDownTime => 125,
-            O::FPartnerRawCltTime => 126,
-            O::FProtocolVersion => 127,
-            O::FKeepaliveTime => 128,
-            O::FReconfigureData => 129,
-            O::FRelationshipName => 130,
-            O::FServerFlags => 131,
-            O::FServerState => 132,
-            O::FStartTimeOfState => 133,
-            O::FStateExpirationTime => 134,
-            O::RelayPort => 135,
-            O::Ipv6AddressANDSF => 143,
-            O::Unknown(n) => n,
-        }
+        opt.0
     }
 }
 
 impl From<u16> for OptionCode {
     fn from(n: u16) -> Self {
-        use OptionCode::*;
-        match n {
-            1 => ClientId,
-            2 => ServerId,
-            3 => IANA,
-            4 => IATA,
-            5 => IAAddr,
-            6 => ORO,
-            7 => Preference,
-            8 => ElapsedTime,
-            9 => RelayMsg,
-            11 => Authentication,
-            12 => ServerUnicast,
-            13 => StatusCode,
-            14 => RapidCommit,
-            15 => UserClass,
-            16 => VendorClass,
-            17 => VendorOpts,
-            18 => InterfaceId,
-            19 => ReconfMsg,
-            20 => ReconfAccept,
-            21 => SipServerD,
-            22 => SipServerA,
-            23 => DomainNameServers,
-            24 => DomainSearchList,
-            25 => IAPD,
-            26 => IAPrefix,
-            27 => NisServers,
-            28 => NispServers,
-            29 => NisDomainName,
-            30 => NispDomainName,
-            31 => SntpServers,
-            32 => InformationRefreshTime,
-            33 => BcmcsServerD,
-            34 => BcmcsServerA,
-            36 => GeoconfCivic,
-            37 => RemoteId,
-            38 => SubscriberId,
-            39 => ClientFqdn,
-            40 => PanaAgent,
-            41 => NewPosixTimezone,
-            42 => NewTzdbTimezone,
-            43 => ERO,
-            44 => LqQuery,
-            45 => ClientData,
-            46 => CltTime,
-            47 => LqRelayData,
-            48 => LqClientLink,
-            49 => Mip6Hnidf,
-            50 => Mip6Vdinf,
-            51 => V6Lost,
-            52 => CapwapAcV6,
-            53 => RelayId,
-            54 => Ipv6AddressMoS,
-            55 => Ipv6FQDNMoS,
-            56 => NtpServer,
-            57 => V6AccessDomain,
-            58 => SipUaCsList,
-            59 => OptBootfileUrl,
-            60 => OptBootfileParam,
-            61 => ClientArchType,
-            62 => Nii,
-            63 => Geolocation,
-            64 => AftrName,
-            65 => ErpLocalDomainName,
-            66 => Rsoo,
-            67 => PdExclude,
-            68 => Vss,
-            69 => Mip6Idinf,
-            70 => Mip6Udinf,
-            71 => Mip6Hnp,
-            72 => Mip6Haa,
-            73 => Mip6Haf,
-            74 => RdnssSelection,
-            75 => KrbPrincipalName,
-            76 => KrbRealmName,
-            77 => KrbDefaultRealmName,
-            78 => KrbKdc,
-            79 => ClientLinklayerAddr,
-            80 => LinkAddress,
-            81 => Radius,
-            82 => SolMaxRt,
-            83 => InfMaxRt,
-            84 => Addrsel,
-            85 => AddrselTable,
-            86 => V6PcpServer,
-            87 => Dhcpv4Msg,
-            88 => Dhcp4ODhcp6Server,
-            89 => S46Rule,
-            90 => S46Br,
-            91 => S46Dmr,
-            92 => S46V4v6bind,
-            93 => S46Portparams,
-            94 => S46ContMape,
-            95 => S46ContMapt,
-            96 => S46ContLw,
-            97 => _4Rd,
-            98 => _4RdMapRule,
-            99 => _4RdNonMapRule,
-            100 => LqBaseTime,
-            101 => LqStartTime,
-            102 => LqEndTime,
-            103 => DhcpCaptivePortal,
-            104 => MplParameters,
-            105 => AniAtt,
-            106 => AniNetworkName,
-            107 => AniApName,
-            108 => AniApBssid,
-            109 => AniOperatorId,
-            110 => AniOperatorRealm,
-            111 => S46Priority,
-            112 => MudUrlV6,
-            113 => V6Prefix64,
-            114 => FBindingStatus,
-            115 => FConnectFlags,
-            116 => Fdnsremovalinfo,
-            117 => FDNSHostName,
-            118 => FDNSZoneName,
-            119 => Fdnsflags,
-            120 => Fexpirationtime,
-            121 => FMaxUnackedBndupd,
-            122 => FMclt,
-            123 => FPartnerLifetime,
-            124 => FPartnerLifetimeSent,
-            125 => FPartnerDownTime,
-            126 => FPartnerRawCltTime,
-            127 => FProtocolVersion,
-            128 => FKeepaliveTime,
-            129 => FReconfigureData,
-            130 => FRelationshipName,
-            131 => FServerFlags,
-            132 => FServerState,
-            133 => FStartTimeOfState,
-            134 => FStateExpirationTime,
-            135 => RelayPort,
-            143 => Ipv6AddressANDSF,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
 
@@ -438,7 +167,7 @@ impl PartialOrd for OptionCode {
 
 impl Ord for OptionCode {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        u16::from(*self).cmp(&u16::from(*other))
+        self.0.cmp(&other.0)
     }
 }
 
@@ -481,7 +210,7 @@ impl From<&DhcpOption> for OptionCode {
             // LqClientLink(_) => OptionCode::LqClientLink,
             // RelayId(_) => OptionCode::RelayId,
             // LinkAddress(_) => OptionCode::LinkAddress,
-            O::Unknown(UnknownOption { code, .. }) => OptionCode::Unknown(*code),
+            O::Unknown(UnknownOption { code, .. }) => OptionCode(*code),
         }
     }
 }

--- a/src/v6/options.rs
+++ b/src/v6/options.rs
@@ -243,94 +243,45 @@ pub struct StatusCode {
 /// Status code for Server Unicast
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Status {
-    Success,
-    UnspecFail,
-    NoAddrsAvail,
-    NoBinding,
-    NotOnLink,
-    UseMulticast,
-    NoPrefixAvail,
-    UnknownQueryType,
-    MalformedQuery,
-    NotConfigured,
-    NotAllowed,
-    QueryTerminated,
-    DataMissing,
-    CatchUpComplete,
-    NotSupported,
-    TLSConnectionRefused,
-    AddressInUse,
-    ConfigurationConflict,
-    MissingBindingInformation,
-    OutdatedBindingInformation,
-    ServerShuttingDown,
-    DNSUpdateNotSupported,
-    ExcessiveTimeSkew,
-    /// unknown/unimplemented message type
-    Unknown(u16),
+#[repr(transparent)]
+pub struct Status(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl Status {
+    pub const Success: Self = Self(0);
+    pub const UnspecFail: Self = Self(1);
+    pub const NoAddrsAvail: Self = Self(2);
+    pub const NoBinding: Self = Self(3);
+    pub const NotOnLink: Self = Self(4);
+    pub const UseMulticast: Self = Self(5);
+    pub const NoPrefixAvail: Self = Self(6);
+    pub const UnknownQueryType: Self = Self(7);
+    pub const MalformedQuery: Self = Self(8);
+    pub const NotConfigured: Self = Self(9);
+    pub const NotAllowed: Self = Self(10);
+    pub const QueryTerminated: Self = Self(11);
+    pub const DataMissing: Self = Self(12);
+    pub const CatchUpComplete: Self = Self(13);
+    pub const NotSupported: Self = Self(14);
+    pub const TLSConnectionRefused: Self = Self(15);
+    pub const AddressInUse: Self = Self(16);
+    pub const ConfigurationConflict: Self = Self(17);
+    pub const MissingBindingInformation: Self = Self(18);
+    pub const OutdatedBindingInformation: Self = Self(19);
+    pub const ServerShuttingDown: Self = Self(20);
+    pub const DNSUpdateNotSupported: Self = Self(21);
+    pub const ExcessiveTimeSkew: Self = Self(22);
 }
 
 impl From<u16> for Status {
     fn from(n: u16) -> Self {
-        use Status::*;
-        match n {
-            0 => Success,
-            1 => UnspecFail,
-            2 => NoAddrsAvail,
-            3 => NoBinding,
-            4 => NotOnLink,
-            5 => UseMulticast,
-            6 => NoPrefixAvail,
-            7 => UnknownQueryType,
-            8 => MalformedQuery,
-            9 => NotConfigured,
-            10 => NotAllowed,
-            11 => QueryTerminated,
-            12 => DataMissing,
-            13 => CatchUpComplete,
-            14 => NotSupported,
-            15 => TLSConnectionRefused,
-            16 => AddressInUse,
-            17 => ConfigurationConflict,
-            18 => MissingBindingInformation,
-            19 => OutdatedBindingInformation,
-            20 => ServerShuttingDown,
-            21 => DNSUpdateNotSupported,
-            22 => ExcessiveTimeSkew,
-            _ => Unknown(n),
-        }
+        Self(n)
     }
 }
+
 impl From<Status> for u16 {
     fn from(n: Status) -> Self {
-        use Status as S;
-        match n {
-            S::Success => 0,
-            S::UnspecFail => 1,
-            S::NoAddrsAvail => 2,
-            S::NoBinding => 3,
-            S::NotOnLink => 4,
-            S::UseMulticast => 5,
-            S::NoPrefixAvail => 6,
-            S::UnknownQueryType => 7,
-            S::MalformedQuery => 8,
-            S::NotConfigured => 9,
-            S::NotAllowed => 10,
-            S::QueryTerminated => 11,
-            S::DataMissing => 12,
-            S::CatchUpComplete => 13,
-            S::NotSupported => 14,
-            S::TLSConnectionRefused => 15,
-            S::AddressInUse => 16,
-            S::ConfigurationConflict => 17,
-            S::MissingBindingInformation => 18,
-            S::OutdatedBindingInformation => 19,
-            S::ServerShuttingDown => 20,
-            S::DNSUpdateNotSupported => 21,
-            S::ExcessiveTimeSkew => 22,
-            S::Unknown(n) => n,
-        }
+        n.0
     }
 }
 
@@ -704,13 +655,9 @@ impl Decodable for DhcpOption {
                 }
                 DhcpOption::ClientArchType(types)
             }
-            // not yet implemented
-            OptionCode::Unknown(code) => DhcpOption::Unknown(UnknownOption {
-                code,
-                data: decoder.read_slice(len)?.to_vec(),
-            }),
-            _ => DhcpOption::Unknown(UnknownOption {
-                code: code.into(),
+            // not yet implemented / unknown
+            code => DhcpOption::Unknown(UnknownOption {
+                code: code.0,
                 data: decoder.read_slice(len)?.to_vec(),
             }),
         })

--- a/src/v6/oro_codes.rs
+++ b/src/v6/oro_codes.rs
@@ -7,227 +7,99 @@ use serde::{Deserialize, Serialize};
 use crate::v6::OptionCode;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum OROCode {
+#[repr(transparent)]
+pub struct OROCode(pub u16);
+
+#[allow(non_upper_case_globals)]
+impl OROCode {
     /// Optional
-    VendorOpts,
-    SipServerD,
-    SipServerA,
-    DomainNameServers,
-    DomainSearchList,
-    NisServers,
-    NispServers,
-    NisDomainName,
-    NispDomainName,
-    SntpServers,
+    pub const VendorOpts: Self = Self(17);
+    pub const SipServerD: Self = Self(21);
+    pub const SipServerA: Self = Self(22);
+    pub const DomainNameServers: Self = Self(23);
+    pub const DomainSearchList: Self = Self(24);
+    pub const NisServers: Self = Self(27);
+    pub const NispServers: Self = Self(28);
+    pub const NisDomainName: Self = Self(29);
+    pub const NispDomainName: Self = Self(30);
+    pub const SntpServers: Self = Self(31);
     /// Required for Information-request
-    InformationRefreshTime,
-    BcmcsServerD,
-    BcmcsServerA,
-    GeoconfCivic,
-    ClientFqdn,
-    PanaAgent,
-    NewPosixTimezone,
-    NewTzdbTimezone,
-    Mip6Hnidf,
-    Mip6Vdinf,
-    V6Lost,
-    CapwapAcV6,
-    Ipv6AddressMoS,
-    Ipv6FQDNMoS,
-    NtpServer,
-    V6AccessDomain,
-    SipUaCsList,
-    OptBootfileUrl,
-    OptBootfileParam,
-    Nii,
-    Geolocation,
-    AftrName,
-    ErpLocalDomainName,
-    PdExclude,
-    Mip6Idinf,
-    Mip6Udinf,
-    Mip6Hnp,
-    Mip6Haa,
-    Mip6Haf,
-    RdnssSelection,
-    KrbPrincipalName,
-    KrbRealmName,
-    KrbDefaultRealmName,
-    KrbKdc,
+    pub const InformationRefreshTime: Self = Self(32);
+    pub const BcmcsServerD: Self = Self(33);
+    pub const BcmcsServerA: Self = Self(34);
+    pub const GeoconfCivic: Self = Self(36);
+    pub const ClientFqdn: Self = Self(39);
+    pub const PanaAgent: Self = Self(40);
+    pub const NewPosixTimezone: Self = Self(41);
+    pub const NewTzdbTimezone: Self = Self(42);
+    pub const Mip6Hnidf: Self = Self(49);
+    pub const Mip6Vdinf: Self = Self(50);
+    pub const V6Lost: Self = Self(51);
+    pub const CapwapAcV6: Self = Self(52);
+    pub const Ipv6AddressMoS: Self = Self(54);
+    pub const Ipv6FQDNMoS: Self = Self(55);
+    pub const NtpServer: Self = Self(56);
+    pub const V6AccessDomain: Self = Self(57);
+    pub const SipUaCsList: Self = Self(58);
+    pub const OptBootfileUrl: Self = Self(59);
+    pub const OptBootfileParam: Self = Self(60);
+    pub const Nii: Self = Self(62);
+    pub const Geolocation: Self = Self(63);
+    pub const AftrName: Self = Self(64);
+    pub const ErpLocalDomainName: Self = Self(65);
+    pub const PdExclude: Self = Self(67);
+    pub const Mip6Idinf: Self = Self(69);
+    pub const Mip6Udinf: Self = Self(70);
+    pub const Mip6Hnp: Self = Self(71);
+    pub const Mip6Haa: Self = Self(72);
+    pub const Mip6Haf: Self = Self(73);
+    pub const RdnssSelection: Self = Self(74);
+    pub const KrbPrincipalName: Self = Self(75);
+    pub const KrbRealmName: Self = Self(76);
+    pub const KrbDefaultRealmName: Self = Self(77);
+    pub const KrbKdc: Self = Self(78);
     /// Required for Solicit
-    SolMaxRt,
+    pub const SolMaxRt: Self = Self(82);
     /// Required for Information-request
-    InfMaxRt,
-    Addrsel,
-    AddrselTable,
-    V6PcpServer,
-    Dhcp4ODhcp6Server,
-    S46ContMape,
-    S46ContMapt,
-    S46ContLw,
-    _4Rd,
-    _4RdMapRule,
-    _4RdNonMapRule,
-    DhcpCaptivePortal,
-    MplParameters,
-    S46Priority,
-    V6Prefix64,
-    Ipv6AddressANDSF,
-    /// Avalible for future codes.
-    Unknown(u16),
+    pub const InfMaxRt: Self = Self(83);
+    pub const Addrsel: Self = Self(84);
+    pub const AddrselTable: Self = Self(85);
+    pub const V6PcpServer: Self = Self(86);
+    pub const Dhcp4ODhcp6Server: Self = Self(88);
+    pub const S46ContMape: Self = Self(94);
+    pub const S46ContMapt: Self = Self(95);
+    pub const S46ContLw: Self = Self(96);
+    pub const _4Rd: Self = Self(97);
+    pub const _4RdMapRule: Self = Self(98);
+    pub const _4RdNonMapRule: Self = Self(99);
+    pub const DhcpCaptivePortal: Self = Self(103);
+    pub const MplParameters: Self = Self(104);
+    pub const S46Priority: Self = Self(111);
+    pub const V6Prefix64: Self = Self(113);
+    pub const Ipv6AddressANDSF: Self = Self(143);
 }
 
 impl From<OROCode> for u16 {
     fn from(opt: OROCode) -> Self {
-        OptionCode::from(opt).into()
+        opt.0
     }
 }
 
 // should this be a TryFrom?
 impl From<u16> for OROCode {
     fn from(opt: u16) -> Self {
-        OptionCode::from(opt)
-            .try_into()
-            .unwrap_or(OROCode::Unknown(opt))
+        OROCode(opt)
     }
 }
 
-impl TryFrom<OptionCode> for OROCode {
-    type Error = &'static str;
-    fn try_from(opt: OptionCode) -> Result<OROCode, Self::Error> {
-        match opt {
-            OptionCode::VendorOpts => Ok(OROCode::VendorOpts),
-            OptionCode::SipServerD => Ok(OROCode::SipServerD),
-            OptionCode::SipServerA => Ok(OROCode::SipServerA),
-            OptionCode::DomainNameServers => Ok(OROCode::DomainNameServers),
-            OptionCode::DomainSearchList => Ok(OROCode::DomainSearchList),
-            OptionCode::NisServers => Ok(OROCode::NisServers),
-            OptionCode::NispServers => Ok(OROCode::NispServers),
-            OptionCode::NisDomainName => Ok(OROCode::NisDomainName),
-            OptionCode::NispDomainName => Ok(OROCode::NispDomainName),
-            OptionCode::SntpServers => Ok(OROCode::SntpServers),
-            OptionCode::InformationRefreshTime => Ok(OROCode::InformationRefreshTime),
-            OptionCode::BcmcsServerD => Ok(OROCode::BcmcsServerD),
-            OptionCode::BcmcsServerA => Ok(OROCode::BcmcsServerA),
-            OptionCode::GeoconfCivic => Ok(OROCode::GeoconfCivic),
-            OptionCode::ClientFqdn => Ok(OROCode::ClientFqdn),
-            OptionCode::PanaAgent => Ok(OROCode::PanaAgent),
-            OptionCode::NewPosixTimezone => Ok(OROCode::NewPosixTimezone),
-            OptionCode::NewTzdbTimezone => Ok(OROCode::NewTzdbTimezone),
-            OptionCode::Mip6Hnidf => Ok(OROCode::Mip6Hnidf),
-            OptionCode::Mip6Vdinf => Ok(OROCode::Mip6Vdinf),
-            OptionCode::V6Lost => Ok(OROCode::V6Lost),
-            OptionCode::CapwapAcV6 => Ok(OROCode::CapwapAcV6),
-            OptionCode::Ipv6AddressMoS => Ok(OROCode::Ipv6AddressMoS),
-            OptionCode::Ipv6FQDNMoS => Ok(OROCode::Ipv6FQDNMoS),
-            OptionCode::NtpServer => Ok(OROCode::NtpServer),
-            OptionCode::V6AccessDomain => Ok(OROCode::V6AccessDomain),
-            OptionCode::SipUaCsList => Ok(OROCode::SipUaCsList),
-            OptionCode::OptBootfileUrl => Ok(OROCode::OptBootfileUrl),
-            OptionCode::OptBootfileParam => Ok(OROCode::OptBootfileParam),
-            OptionCode::Nii => Ok(OROCode::Nii),
-            OptionCode::Geolocation => Ok(OROCode::Geolocation),
-            OptionCode::AftrName => Ok(OROCode::AftrName),
-            OptionCode::ErpLocalDomainName => Ok(OROCode::ErpLocalDomainName),
-            OptionCode::PdExclude => Ok(OROCode::PdExclude),
-            OptionCode::Mip6Idinf => Ok(OROCode::Mip6Idinf),
-            OptionCode::Mip6Udinf => Ok(OROCode::Mip6Udinf),
-            OptionCode::Mip6Hnp => Ok(OROCode::Mip6Hnp),
-            OptionCode::Mip6Haa => Ok(OROCode::Mip6Haa),
-            OptionCode::Mip6Haf => Ok(OROCode::Mip6Haf),
-            OptionCode::RdnssSelection => Ok(OROCode::RdnssSelection),
-            OptionCode::KrbPrincipalName => Ok(OROCode::KrbPrincipalName),
-            OptionCode::KrbRealmName => Ok(OROCode::KrbRealmName),
-            OptionCode::KrbDefaultRealmName => Ok(OROCode::KrbDefaultRealmName),
-            OptionCode::KrbKdc => Ok(OROCode::KrbKdc),
-            OptionCode::SolMaxRt => Ok(OROCode::SolMaxRt),
-            OptionCode::InfMaxRt => Ok(OROCode::InfMaxRt),
-            OptionCode::Addrsel => Ok(OROCode::Addrsel),
-            OptionCode::AddrselTable => Ok(OROCode::AddrselTable),
-            OptionCode::V6PcpServer => Ok(OROCode::V6PcpServer),
-            OptionCode::Dhcp4ODhcp6Server => Ok(OROCode::Dhcp4ODhcp6Server),
-            OptionCode::S46ContMape => Ok(OROCode::S46ContMape),
-            OptionCode::S46ContMapt => Ok(OROCode::S46ContMapt),
-            OptionCode::S46ContLw => Ok(OROCode::S46ContLw),
-            OptionCode::_4Rd => Ok(OROCode::_4Rd),
-            OptionCode::_4RdMapRule => Ok(OROCode::_4RdMapRule),
-            OptionCode::_4RdNonMapRule => Ok(OROCode::_4RdNonMapRule),
-            OptionCode::DhcpCaptivePortal => Ok(OROCode::DhcpCaptivePortal),
-            OptionCode::MplParameters => Ok(OROCode::MplParameters),
-            OptionCode::S46Priority => Ok(OROCode::S46Priority),
-            OptionCode::V6Prefix64 => Ok(OROCode::V6Prefix64),
-            OptionCode::Ipv6AddressANDSF => Ok(OROCode::Ipv6AddressANDSF),
-            OptionCode::Unknown(u16) => Ok(OROCode::Unknown(u16)),
-            _ => Err("conversion error, is not a valid OROCode"),
-        }
+impl From<OptionCode> for OROCode {
+    fn from(opt: OptionCode) -> OROCode {
+        OROCode(opt.0)
     }
 }
 
 impl From<OROCode> for OptionCode {
     fn from(opt: OROCode) -> OptionCode {
-        match opt {
-            OROCode::VendorOpts => OptionCode::VendorOpts,
-            OROCode::SipServerD => OptionCode::SipServerD,
-            OROCode::SipServerA => OptionCode::SipServerA,
-            OROCode::DomainNameServers => OptionCode::DomainNameServers,
-            OROCode::DomainSearchList => OptionCode::DomainSearchList,
-            OROCode::NisServers => OptionCode::NisServers,
-            OROCode::NispServers => OptionCode::NispServers,
-            OROCode::NisDomainName => OptionCode::NisDomainName,
-            OROCode::NispDomainName => OptionCode::NispDomainName,
-            OROCode::SntpServers => OptionCode::SntpServers,
-            OROCode::InformationRefreshTime => OptionCode::InformationRefreshTime,
-            OROCode::BcmcsServerD => OptionCode::BcmcsServerD,
-            OROCode::BcmcsServerA => OptionCode::BcmcsServerA,
-            OROCode::GeoconfCivic => OptionCode::GeoconfCivic,
-            OROCode::ClientFqdn => OptionCode::ClientFqdn,
-            OROCode::PanaAgent => OptionCode::PanaAgent,
-            OROCode::NewPosixTimezone => OptionCode::NewPosixTimezone,
-            OROCode::NewTzdbTimezone => OptionCode::NewTzdbTimezone,
-            OROCode::Mip6Hnidf => OptionCode::Mip6Hnidf,
-            OROCode::Mip6Vdinf => OptionCode::Mip6Vdinf,
-            OROCode::V6Lost => OptionCode::V6Lost,
-            OROCode::CapwapAcV6 => OptionCode::CapwapAcV6,
-            OROCode::Ipv6AddressMoS => OptionCode::Ipv6AddressMoS,
-            OROCode::Ipv6FQDNMoS => OptionCode::Ipv6FQDNMoS,
-            OROCode::NtpServer => OptionCode::NtpServer,
-            OROCode::V6AccessDomain => OptionCode::V6AccessDomain,
-            OROCode::SipUaCsList => OptionCode::SipUaCsList,
-            OROCode::OptBootfileUrl => OptionCode::OptBootfileUrl,
-            OROCode::OptBootfileParam => OptionCode::OptBootfileParam,
-            OROCode::Nii => OptionCode::Nii,
-            OROCode::Geolocation => OptionCode::Geolocation,
-            OROCode::AftrName => OptionCode::AftrName,
-            OROCode::ErpLocalDomainName => OptionCode::ErpLocalDomainName,
-            OROCode::PdExclude => OptionCode::PdExclude,
-            OROCode::Mip6Idinf => OptionCode::Mip6Idinf,
-            OROCode::Mip6Udinf => OptionCode::Mip6Udinf,
-            OROCode::Mip6Hnp => OptionCode::Mip6Hnp,
-            OROCode::Mip6Haa => OptionCode::Mip6Haa,
-            OROCode::Mip6Haf => OptionCode::Mip6Haf,
-            OROCode::RdnssSelection => OptionCode::RdnssSelection,
-            OROCode::KrbPrincipalName => OptionCode::KrbPrincipalName,
-            OROCode::KrbRealmName => OptionCode::KrbRealmName,
-            OROCode::KrbDefaultRealmName => OptionCode::KrbDefaultRealmName,
-            OROCode::KrbKdc => OptionCode::KrbKdc,
-            OROCode::SolMaxRt => OptionCode::SolMaxRt,
-            OROCode::InfMaxRt => OptionCode::InfMaxRt,
-            OROCode::Addrsel => OptionCode::Addrsel,
-            OROCode::AddrselTable => OptionCode::AddrselTable,
-            OROCode::V6PcpServer => OptionCode::V6PcpServer,
-            OROCode::Dhcp4ODhcp6Server => OptionCode::Dhcp4ODhcp6Server,
-            OROCode::S46ContMape => OptionCode::S46ContMape,
-            OROCode::S46ContMapt => OptionCode::S46ContMapt,
-            OROCode::S46ContLw => OptionCode::S46ContLw,
-            OROCode::_4Rd => OptionCode::_4Rd,
-            OROCode::_4RdMapRule => OptionCode::_4RdMapRule,
-            OROCode::_4RdNonMapRule => OptionCode::_4RdNonMapRule,
-            OROCode::DhcpCaptivePortal => OptionCode::DhcpCaptivePortal,
-            OROCode::MplParameters => OptionCode::MplParameters,
-            OROCode::S46Priority => OptionCode::S46Priority,
-            OROCode::V6Prefix64 => OptionCode::V6Prefix64,
-            OROCode::Ipv6AddressANDSF => OptionCode::Ipv6AddressANDSF,
-            OROCode::Unknown(u16) => OptionCode::Unknown(u16),
-        }
+        OptionCode(opt.0)
     }
 }

--- a/src/v6/oro_codes.rs
+++ b/src/v6/oro_codes.rs
@@ -66,6 +66,7 @@ impl OROCode {
     pub const AddrselTable: Self = Self(85);
     pub const V6PcpServer: Self = Self(86);
     pub const Dhcp4ODhcp6Server: Self = Self(88);
+    pub const S46Br: Self = Self(90);
     pub const S46ContMape: Self = Self(94);
     pub const S46ContMapt: Self = Self(95);
     pub const S46ContLw: Self = Self(96);
@@ -77,6 +78,75 @@ impl OROCode {
     pub const S46Priority: Self = Self(111);
     pub const V6Prefix64: Self = Self(113);
     pub const Ipv6AddressANDSF: Self = Self(143);
+
+    /// Returns `true` if this code is a known/valid ORO-requestable option.
+    pub fn is_known(self) -> bool {
+        matches!(
+            self,
+            Self::VendorOpts
+                | Self::SipServerD
+                | Self::SipServerA
+                | Self::DomainNameServers
+                | Self::DomainSearchList
+                | Self::NisServers
+                | Self::NispServers
+                | Self::NisDomainName
+                | Self::NispDomainName
+                | Self::SntpServers
+                | Self::InformationRefreshTime
+                | Self::BcmcsServerD
+                | Self::BcmcsServerA
+                | Self::GeoconfCivic
+                | Self::ClientFqdn
+                | Self::PanaAgent
+                | Self::NewPosixTimezone
+                | Self::NewTzdbTimezone
+                | Self::Mip6Hnidf
+                | Self::Mip6Vdinf
+                | Self::V6Lost
+                | Self::CapwapAcV6
+                | Self::Ipv6AddressMoS
+                | Self::Ipv6FQDNMoS
+                | Self::NtpServer
+                | Self::V6AccessDomain
+                | Self::SipUaCsList
+                | Self::OptBootfileUrl
+                | Self::OptBootfileParam
+                | Self::Nii
+                | Self::Geolocation
+                | Self::AftrName
+                | Self::ErpLocalDomainName
+                | Self::PdExclude
+                | Self::Mip6Idinf
+                | Self::Mip6Udinf
+                | Self::Mip6Hnp
+                | Self::Mip6Haa
+                | Self::Mip6Haf
+                | Self::RdnssSelection
+                | Self::KrbPrincipalName
+                | Self::KrbRealmName
+                | Self::KrbDefaultRealmName
+                | Self::KrbKdc
+                | Self::SolMaxRt
+                | Self::InfMaxRt
+                | Self::Addrsel
+                | Self::AddrselTable
+                | Self::V6PcpServer
+                | Self::Dhcp4ODhcp6Server
+                | Self::S46Br
+                | Self::S46ContMape
+                | Self::S46ContMapt
+                | Self::S46ContLw
+                | Self::_4Rd
+                | Self::_4RdMapRule
+                | Self::_4RdNonMapRule
+                | Self::DhcpCaptivePortal
+                | Self::MplParameters
+                | Self::S46Priority
+                | Self::V6Prefix64
+                | Self::Ipv6AddressANDSF
+        )
+    }
 }
 
 impl From<OROCode> for u16 {
@@ -85,16 +155,19 @@ impl From<OROCode> for u16 {
     }
 }
 
-// should this be a TryFrom?
 impl From<u16> for OROCode {
     fn from(opt: u16) -> Self {
         OROCode(opt)
     }
 }
 
-impl From<OptionCode> for OROCode {
-    fn from(opt: OptionCode) -> OROCode {
-        OROCode(opt.0)
+impl TryFrom<OptionCode> for OROCode {
+    type Error = OptionCode;
+    /// Converts an [`OptionCode`] to an [`OROCode`], returning `Err` if the
+    /// code is not a known ORO-requestable option.
+    fn try_from(opt: OptionCode) -> Result<OROCode, Self::Error> {
+        let code = OROCode(opt.0);
+        if code.is_known() { Ok(code) } else { Err(opt) }
     }
 }
 


### PR DESCRIPTION
closes #100 

similar to the other PR but includes OROCode + RelayCode + v6::OptionCode. I see no reason not to include these in the change set.